### PR TITLE
Implement core type system and NodeDefinition interfaces

### DIFF
--- a/src/__tests__/core-type-system.test.ts
+++ b/src/__tests__/core-type-system.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PortType,
+  PORT_TYPE_REGISTRY,
+  isTypeCompatible
+} from '../shared/types'
+import type {
+  NodeDefinition,
+  PortDefinition,
+  ParameterDefinition,
+  ExecutionContext
+} from '../shared/types'
+
+// ---------------------------------------------------------------------------
+// isTypeCompatible — happy path and edge cases
+// ---------------------------------------------------------------------------
+
+describe('isTypeCompatible', () => {
+  // Happy path: identical types are always compatible
+  it('returns true for identical concrete types', () => {
+    expect(isTypeCompatible(PortType.IMAGE, PortType.IMAGE)).toBe(true)
+    expect(isTypeCompatible(PortType.TEXT, PortType.TEXT)).toBe(true)
+    expect(isTypeCompatible(PortType.NUMBER, PortType.NUMBER)).toBe(true)
+    expect(isTypeCompatible(PortType.JSON, PortType.JSON)).toBe(true)
+  })
+
+  // Edge case 1: ANY source is compatible with every target
+  it('returns true when source is ANY (ANY → all)', () => {
+    expect(isTypeCompatible(PortType.ANY, PortType.IMAGE)).toBe(true)
+    expect(isTypeCompatible(PortType.ANY, PortType.TEXT)).toBe(true)
+    expect(isTypeCompatible(PortType.ANY, PortType.NUMBER)).toBe(true)
+    expect(isTypeCompatible(PortType.ANY, PortType.JSON)).toBe(true)
+    expect(isTypeCompatible(PortType.ANY, PortType.ANY)).toBe(true)
+  })
+
+  // Edge case 2: ANY target accepts every source
+  it('returns true when target is ANY (all → ANY)', () => {
+    expect(isTypeCompatible(PortType.IMAGE, PortType.ANY)).toBe(true)
+    expect(isTypeCompatible(PortType.TEXT, PortType.ANY)).toBe(true)
+    expect(isTypeCompatible(PortType.NUMBER, PortType.ANY)).toBe(true)
+    expect(isTypeCompatible(PortType.JSON, PortType.ANY)).toBe(true)
+  })
+
+  // Edge case 3: mismatched concrete types are incompatible
+  it('returns false for IMAGE → TEXT (strict type mismatch)', () => {
+    expect(isTypeCompatible(PortType.IMAGE, PortType.TEXT)).toBe(false)
+  })
+
+  it('returns false for TEXT → NUMBER', () => {
+    expect(isTypeCompatible(PortType.TEXT, PortType.NUMBER)).toBe(false)
+  })
+
+  it('returns false for NUMBER → JSON', () => {
+    expect(isTypeCompatible(PortType.NUMBER, PortType.JSON)).toBe(false)
+  })
+
+  it('returns false for JSON → IMAGE', () => {
+    expect(isTypeCompatible(PortType.JSON, PortType.IMAGE)).toBe(false)
+  })
+
+  it('returns false for IMAGE → NUMBER', () => {
+    expect(isTypeCompatible(PortType.IMAGE, PortType.NUMBER)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PORT_TYPE_REGISTRY — registry completeness and color values
+// ---------------------------------------------------------------------------
+
+describe('PORT_TYPE_REGISTRY', () => {
+  it('contains entries for all 5 PortType values', () => {
+    const allTypes = Object.values(PortType)
+    allTypes.forEach(type => {
+      expect(PORT_TYPE_REGISTRY[type]).toBeDefined()
+    })
+  })
+
+  it('has correct color hex codes', () => {
+    expect(PORT_TYPE_REGISTRY[PortType.IMAGE].color).toBe('#64B5F6')
+    expect(PORT_TYPE_REGISTRY[PortType.TEXT].color).toBe('#81C784')
+    expect(PORT_TYPE_REGISTRY[PortType.NUMBER].color).toBe('#FFB74D')
+    expect(PORT_TYPE_REGISTRY[PortType.JSON].color).toBe('#CE93D8')
+    expect(PORT_TYPE_REGISTRY[PortType.ANY].color).toBe('#9E9E9E')
+  })
+
+  it('every entry has a non-empty label', () => {
+    Object.values(PORT_TYPE_REGISTRY).forEach(meta => {
+      expect(typeof meta.label).toBe('string')
+      expect(meta.label.length).toBeGreaterThan(0)
+    })
+  })
+
+  it('every color follows hex color format', () => {
+    Object.values(PORT_TYPE_REGISTRY).forEach(meta => {
+      expect(meta.color).toMatch(/^#[0-9A-Fa-f]{6}$/)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PortDefinition — structural shape
+// ---------------------------------------------------------------------------
+
+describe('PortDefinition structural conformance', () => {
+  it('accepts a valid input port definition', () => {
+    const port: PortDefinition = {
+      name: 'image_in',
+      type: PortType.IMAGE,
+      label: 'Input Image'
+    }
+    expect(port.name).toBe('image_in')
+    expect(port.type).toBe(PortType.IMAGE)
+    expect(port.defaultValue).toBeUndefined()
+  })
+
+  it('accepts a port definition with a default value', () => {
+    const port: PortDefinition = {
+      name: 'prompt',
+      type: PortType.TEXT,
+      label: 'Prompt',
+      defaultValue: 'A beautiful landscape'
+    }
+    expect(port.defaultValue).toBe('A beautiful landscape')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ParameterDefinition — structural shape and constraints
+// ---------------------------------------------------------------------------
+
+describe('ParameterDefinition structural conformance', () => {
+  it('accepts a slider parameter with min/max constraints', () => {
+    const param: ParameterDefinition = {
+      name: 'temperature',
+      type: 'slider',
+      label: 'Temperature',
+      default: 0.7,
+      constraints: { min: 0, max: 1, step: 0.01 }
+    }
+    expect(param.constraints?.min).toBe(0)
+    expect(param.constraints?.max).toBe(1)
+  })
+
+  it('accepts a select parameter with options', () => {
+    const param: ParameterDefinition = {
+      name: 'model',
+      type: 'select',
+      label: 'Model',
+      default: 'imagen-3',
+      constraints: {
+        options: [
+          { value: 'imagen-3', label: 'Imagen 3' },
+          { value: 'imagen-3-fast', label: 'Imagen 3 Fast' }
+        ]
+      }
+    }
+    expect(param.constraints?.options).toHaveLength(2)
+  })
+
+  it('accepts a boolean parameter without constraints', () => {
+    const param: ParameterDefinition = {
+      name: 'enhance',
+      type: 'boolean',
+      label: 'Enhance',
+      default: false
+    }
+    expect(param.default).toBe(false)
+    expect(param.constraints).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// NodeDefinition — structural shape and mandatory fields
+// ---------------------------------------------------------------------------
+
+describe('NodeDefinition structural conformance', () => {
+  const mockContext: ExecutionContext = {
+    reportProgress: () => {},
+    getSecret: async () => undefined,
+    abortSignal: new AbortController().signal,
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {}
+    }
+  }
+
+  it('accepts a fully populated node definition', () => {
+    const node: NodeDefinition = {
+      id: 'test:my-node',
+      version: '1.0.0',
+      name: 'My Test Node',
+      category: 'Utilities',
+      inputs: [{ name: 'in', type: PortType.ANY, label: 'Input' }],
+      outputs: [{ name: 'out', type: PortType.ANY, label: 'Output' }],
+      parameters: [],
+      execute: async (_inputs, _params, _ctx) => ({ out: null })
+    }
+    expect(node.id).toBe('test:my-node')
+    expect(node.inputs).toHaveLength(1)
+    expect(node.outputs).toHaveLength(1)
+  })
+
+  it('execute function receives correct arguments', async () => {
+    const receivedArgs: unknown[] = []
+    const node: NodeDefinition = {
+      id: 'test:spy-node',
+      version: '1.0.0',
+      name: 'Spy Node',
+      category: 'Test',
+      inputs: [],
+      outputs: [],
+      parameters: [],
+      execute: async (inputs, params, ctx) => {
+        receivedArgs.push(inputs, params, ctx)
+        return {}
+      }
+    }
+
+    const inputs = { image: 'blob:data' }
+    const params = { scale: 2 }
+    await node.execute(inputs, params, mockContext)
+
+    expect(receivedArgs[0]).toEqual(inputs)
+    expect(receivedArgs[1]).toEqual(params)
+    expect(receivedArgs[2]).toBe(mockContext)
+  })
+
+  it('execute function returns a promise resolving to a record', async () => {
+    const node: NodeDefinition = {
+      id: 'test:passthrough',
+      version: '1.0.0',
+      name: 'Passthrough',
+      category: 'Test',
+      inputs: [{ name: 'value', type: PortType.ANY, label: 'Value' }],
+      outputs: [{ name: 'value', type: PortType.ANY, label: 'Value' }],
+      parameters: [],
+      execute: async (inputs) => ({ value: inputs['value'] })
+    }
+
+    const result = await node.execute({ value: 42 }, {}, mockContext)
+    expect(result['value']).toBe(42)
+  })
+
+  it('customComponent is optional and defaults to undefined', () => {
+    const node: NodeDefinition = {
+      id: 'test:no-custom',
+      version: '1.0.0',
+      name: 'No Custom',
+      category: 'Test',
+      inputs: [],
+      outputs: [],
+      parameters: [],
+      execute: async () => ({})
+    }
+    expect(node.customComponent).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ExecutionContext — interface structure
+// ---------------------------------------------------------------------------
+
+describe('ExecutionContext structural conformance', () => {
+  it('reportProgress can be called with progress and message', () => {
+    const calls: Array<[number, string | undefined]> = []
+    const ctx: ExecutionContext = {
+      reportProgress: (p, msg) => calls.push([p, msg]),
+      getSecret: async () => undefined,
+      abortSignal: new AbortController().signal,
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: () => {},
+        error: () => {}
+      }
+    }
+
+    ctx.reportProgress(0.5, 'halfway')
+    expect(calls).toEqual([[0.5, 'halfway']])
+  })
+
+  it('getSecret returns undefined for unknown keys', async () => {
+    const ctx: ExecutionContext = {
+      reportProgress: () => {},
+      getSecret: async (key) => (key === 'KNOWN' ? 'secret' : undefined),
+      abortSignal: new AbortController().signal,
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
+    }
+
+    expect(await ctx.getSecret('UNKNOWN')).toBeUndefined()
+    expect(await ctx.getSecret('KNOWN')).toBe('secret')
+  })
+
+  it('abortSignal reflects AbortController state', () => {
+    const controller = new AbortController()
+    const ctx: ExecutionContext = {
+      reportProgress: () => {},
+      getSecret: async () => undefined,
+      abortSignal: controller.signal,
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
+    }
+
+    expect(ctx.abortSignal.aborted).toBe(false)
+    controller.abort()
+    expect(ctx.abortSignal.aborted).toBe(true)
+  })
+})

--- a/src/shared/types/app-types.ts
+++ b/src/shared/types/app-types.ts
@@ -1,5 +1,5 @@
 /**
- * Shared types used across main, preload, and renderer processes.
+ * General application types shared across main, preload, and renderer processes.
  */
 
 export interface AppInfo {
@@ -7,9 +7,11 @@ export interface AppInfo {
   platform: NodeJS.Platform
 }
 
+/** Generic data payload attached to a React Flow node. */
 export interface NodeData {
   label: string
   [key: string]: unknown
 }
 
+/** Built-in node type identifiers used by the initial scaffold nodes. */
 export type NodeType = 'imageSource' | 'filter' | 'output' | 'custom'

--- a/src/shared/types/execution-context.ts
+++ b/src/shared/types/execution-context.ts
@@ -1,0 +1,45 @@
+/**
+ * Execution context passed to node execute functions.
+ * Provides utilities for progress reporting, secret retrieval,
+ * cancellation, and logging.
+ */
+
+/** Log levels supported by the execution logger. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/** Logger interface available during node execution. */
+export interface ExecutionLogger {
+  debug(message: string, ...args: unknown[]): void
+  info(message: string, ...args: unknown[]): void
+  warn(message: string, ...args: unknown[]): void
+  error(message: string, ...args: unknown[]): void
+}
+
+/**
+ * Context object injected into every node's execute function.
+ * Provides runtime utilities for progress, secrets, cancellation, and logging.
+ */
+export interface ExecutionContext {
+  /**
+   * Report execution progress as a value between 0 and 1.
+   * @param progress - Fraction of work completed (0.0 to 1.0)
+   * @param message - Optional human-readable status message
+   */
+  reportProgress(progress: number, message?: string): void
+
+  /**
+   * Retrieve a named secret (e.g. API key) from secure storage.
+   * @param key - The name of the secret to retrieve
+   * @returns The secret value, or undefined if not found
+   */
+  getSecret(key: string): Promise<string | undefined>
+
+  /**
+   * AbortSignal for detecting cancellation of the execution.
+   * Nodes should check this signal and throw if aborted.
+   */
+  abortSignal: AbortSignal
+
+  /** Logger for emitting structured log messages during execution. */
+  logger: ExecutionLogger
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Core type system for the node-based image generation editor.
+ *
+ * All types are exported from this barrel file so both the main process
+ * and renderer process can import from `@shared/types`.
+ *
+ * @example
+ *   import { NodeDefinition, PortType, isTypeCompatible } from '@shared/types'
+ */
+
+export type { AppInfo, NodeData, NodeType } from './app-types'
+export type { PortDefinition } from './port-definition'
+export type { ParameterDefinition, ParameterConstraints, ParameterType } from './parameter-definition'
+export type { ExecutionContext, ExecutionLogger, LogLevel } from './execution-context'
+export type { NodeDefinition, NodeExecuteFunction } from './node-definition'
+export { PortType, PORT_TYPE_REGISTRY, isTypeCompatible } from './port-types'
+export type { PortTypeMetadata } from './port-types'

--- a/src/shared/types/node-definition.ts
+++ b/src/shared/types/node-definition.ts
@@ -1,0 +1,63 @@
+/**
+ * NodeDefinition interface — the primary contract for all node plugins.
+ * A node definition provides declarative metadata about the node's ports
+ * and parameters, plus an async execute function that performs the work.
+ */
+
+import type { ComponentType } from 'react'
+import type { PortDefinition } from './port-definition'
+import type { ParameterDefinition } from './parameter-definition'
+import type { ExecutionContext } from './execution-context'
+
+/**
+ * The async function that performs a node's computation.
+ * @param inputs - Values arriving on input ports, keyed by port name
+ * @param params - Current parameter values, keyed by parameter name
+ * @param context - Runtime utilities (progress, secrets, abort, logger)
+ * @returns A record of output values keyed by output port name
+ */
+export type NodeExecuteFunction = (
+  inputs: Record<string, unknown>,
+  params: Record<string, unknown>,
+  context: ExecutionContext
+) => Promise<Record<string, unknown>>
+
+/**
+ * Full definition of a node type in the plugin system.
+ * This interface is the single source of truth for a node's identity,
+ * connectivity, configuration, and execution behavior.
+ */
+export interface NodeDefinition {
+  /** Unique identifier for this node type (e.g. "vertex-ai:imagen"). */
+  id: string
+
+  /** Semantic version string (e.g. "1.0.0"). */
+  version: string
+
+  /** Human-readable display name shown in the palette and on the canvas. */
+  name: string
+
+  /**
+   * Category for grouping in the node palette
+   * (e.g. "Image Generation", "Utilities").
+   */
+  category: string
+
+  /** Ordered list of input port definitions. */
+  inputs: PortDefinition[]
+
+  /** Ordered list of output port definitions. */
+  outputs: PortDefinition[]
+
+  /** List of configurable parameters shown in the properties panel. */
+  parameters: ParameterDefinition[]
+
+  /** The async function invoked when this node is executed. */
+  execute: NodeExecuteFunction
+
+  /**
+   * Optional custom React component to render in place of the default
+   * node card. If omitted, the default node renderer is used.
+   */
+  customComponent?: ComponentType<{ id: string; data: Record<string, unknown> }>
+}

--- a/src/shared/types/parameter-definition.ts
+++ b/src/shared/types/parameter-definition.ts
@@ -1,0 +1,50 @@
+/**
+ * Parameter definition types for node configuration controls.
+ * Parameters are editable via the properties panel and do not require
+ * a port connection — they represent static configuration values.
+ */
+
+/** The UI control type rendered for a parameter. */
+export type ParameterType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'select'
+  | 'slider'
+  | 'text-area'
+
+/** Constraints applied to a parameter based on its type. */
+export interface ParameterConstraints {
+  /** Minimum value (applies to number and slider types). */
+  min?: number
+
+  /** Maximum value (applies to number and slider types). */
+  max?: number
+
+  /** Step increment (applies to number and slider types). */
+  step?: number
+
+  /** Allowed values for select type. */
+  options?: Array<{ value: string | number; label: string }>
+}
+
+/**
+ * Defines a configurable parameter on a node.
+ * Parameters are displayed in the properties panel as form controls.
+ */
+export interface ParameterDefinition {
+  /** Internal identifier for the parameter (must be unique within the node). */
+  name: string
+
+  /** The UI control type to render for this parameter. */
+  type: ParameterType
+
+  /** Human-readable label shown in the UI. */
+  label: string
+
+  /** Default value used when the parameter has not been set by the user. */
+  default: string | number | boolean
+
+  /** Optional constraints that restrict valid values. */
+  constraints?: ParameterConstraints
+}

--- a/src/shared/types/port-definition.ts
+++ b/src/shared/types/port-definition.ts
@@ -1,0 +1,26 @@
+/**
+ * Port definition types for node inputs and outputs.
+ */
+
+import { PortType } from './port-types'
+
+/**
+ * Defines a single input or output port on a node.
+ * Ports carry typed data between connected nodes.
+ */
+export interface PortDefinition {
+  /** Internal identifier for the port (must be unique within the node). */
+  name: string
+
+  /** The data type this port accepts or produces. */
+  type: PortType
+
+  /** Human-readable label shown in the UI. */
+  label: string
+
+  /**
+   * Optional default value used when no connection is present.
+   * Only applicable to input ports.
+   */
+  defaultValue?: unknown
+}

--- a/src/shared/types/port-types.ts
+++ b/src/shared/types/port-types.ts
@@ -1,0 +1,50 @@
+/**
+ * Port type registry for the node system.
+ * Defines the 5 core data types that can flow between node ports,
+ * each with a color hex code and compatibility rules.
+ *
+ * A const object is used instead of TypeScript enum to ensure full
+ * compatibility with esbuild's strip-only transform (used by Vite/Vitest).
+ */
+
+/** The 5 core port types supported by the node system. */
+export const PortType = {
+  IMAGE: 'IMAGE',
+  TEXT: 'TEXT',
+  NUMBER: 'NUMBER',
+  JSON: 'JSON',
+  ANY: 'ANY'
+} as const
+
+/** Union type of all valid port type string values. */
+export type PortType = (typeof PortType)[keyof typeof PortType]
+
+/** Metadata for a port type including display color. */
+export interface PortTypeMetadata {
+  color: string
+  label: string
+}
+
+/** Registry of port type metadata keyed by PortType. */
+export const PORT_TYPE_REGISTRY: Record<PortType, PortTypeMetadata> = {
+  [PortType.IMAGE]: { color: '#64B5F6', label: 'Image' },
+  [PortType.TEXT]: { color: '#81C784', label: 'Text' },
+  [PortType.NUMBER]: { color: '#FFB74D', label: 'Number' },
+  [PortType.JSON]: { color: '#CE93D8', label: 'JSON' },
+  [PortType.ANY]: { color: '#9E9E9E', label: 'Any' }
+}
+
+/**
+ * Determines whether a connection from source to target is type-compatible.
+ * ANY type is compatible with all other types in both directions.
+ *
+ * @param source - The port type of the output (source) port
+ * @param target - The port type of the input (target) port
+ * @returns true if the types are compatible and a connection is valid
+ */
+export function isTypeCompatible(source: PortType, target: PortType): boolean {
+  if (source === PortType.ANY || target === PortType.ANY) {
+    return true
+  }
+  return source === target
+}


### PR DESCRIPTION
## Summary
Defines the TypeScript type foundation for the node-based image generation editor. All types are placed in `src/shared/types/` so both the main and renderer processes can import from `@shared/types`.

## Changes
- `src/shared/types/port-types.ts` — `PortType` const object (IMAGE/TEXT/NUMBER/JSON/ANY), `PORT_TYPE_REGISTRY` with hex colors, `isTypeCompatible()` function
- `src/shared/types/port-definition.ts` — `PortDefinition` interface (name, type, label, optional defaultValue)
- `src/shared/types/parameter-definition.ts` — `ParameterDefinition` interface with `ParameterType` and `ParameterConstraints`
- `src/shared/types/execution-context.ts` — `ExecutionContext` interface (reportProgress, getSecret, abortSignal, logger)
- `src/shared/types/node-definition.ts` — `NodeDefinition` interface with typed `execute` function signature
- `src/shared/types/app-types.ts` — Migrated `AppInfo`, `NodeData`, `NodeType` from the old flat `types.ts`
- `src/shared/types/index.ts` — Barrel re-export of all types for `@shared/types` path alias
- `src/__tests__/core-type-system.test.ts` — 24 unit tests covering isTypeCompatible (ANY semantics, strict mismatches), registry completeness, and structural conformance

## Test Plan
- Run `npx vitest run` — 39 tests pass (24 new, 15 existing)
- Run `npx tsc --noEmit -p tsconfig.node.json` — no errors
- Run `npx tsc --noEmit -p tsconfig.web.json` — no errors
- Run `bash scripts/ci-lint.sh` — PASS
- Run `bash scripts/ci-file-size.sh` — PASS

## Notes
- `PortType` uses `as const` pattern instead of TypeScript `enum` for esbuild/Vite compatibility
- Old `src/shared/types.ts` is migrated into the new modular structure (backward-compatible)

Fixes #23