### PR TITLE
Implement three-panel layout with React Flow canvas

### DIFF
--- a/src/__tests__/layout-state.test.ts
+++ b/src/__tests__/layout-state.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useUiStore } from '../renderer/src/store/ui-store'
+
+const LEFT_PANEL_WIDTH = 250
+const RIGHT_PANEL_WIDTH = 300
+
+/**
+ * Tests for layout panel width computation logic —
+ * mirrors the logic used in Layout.tsx to derive panel widths.
+ */
+function getPanelWidth(isOpen: boolean, defaultWidth: number): number {
+  return isOpen ? defaultWidth : 0
+}
+
+describe('Layout panel width logic', () => {
+  beforeEach(() => {
+    useUiStore.setState({ leftPanelOpen: true, rightPanelOpen: true })
+  })
+
+  // Happy path: three-panel layout renders with correct widths
+  it('both panels have correct default widths when open', () => {
+    const state = useUiStore.getState()
+    expect(getPanelWidth(state.leftPanelOpen, LEFT_PANEL_WIDTH)).toBe(250)
+    expect(getPanelWidth(state.rightPanelOpen, RIGHT_PANEL_WIDTH)).toBe(300)
+  })
+
+  // Edge case 1: collapse left sidebar — canvas expands (left panel width = 0)
+  it('left panel collapses to width 0', () => {
+    useUiStore.getState().toggleLeftPanel()
+    const state = useUiStore.getState()
+    expect(getPanelWidth(state.leftPanelOpen, LEFT_PANEL_WIDTH)).toBe(0)
+    expect(getPanelWidth(state.rightPanelOpen, RIGHT_PANEL_WIDTH)).toBe(300)
+  })
+
+  // Edge case 2: collapse both sidebars — canvas fills entire window
+  it('both panels collapse to width 0', () => {
+    const store = useUiStore.getState()
+    store.toggleLeftPanel()
+    store.toggleRightPanel()
+    const state = useUiStore.getState()
+    expect(getPanelWidth(state.leftPanelOpen, LEFT_PANEL_WIDTH)).toBe(0)
+    expect(getPanelWidth(state.rightPanelOpen, RIGHT_PANEL_WIDTH)).toBe(0)
+  })
+
+  // Edge case 3: panels expand back after collapsing
+  it('panels return to full width after re-expanding', () => {
+    const store = useUiStore.getState()
+    store.toggleLeftPanel()
+    useUiStore.getState().toggleLeftPanel()
+    const state = useUiStore.getState()
+    expect(getPanelWidth(state.leftPanelOpen, LEFT_PANEL_WIDTH)).toBe(250)
+  })
+})

--- a/src/__tests__/ui-store.test.ts
+++ b/src/__tests__/ui-store.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useUiStore } from '../renderer/src/store/ui-store'
+
+describe('useUiStore', () => {
+  // Reset store state between tests
+  beforeEach(() => {
+    useUiStore.setState({ leftPanelOpen: true, rightPanelOpen: true })
+  })
+
+  // Happy path: default state has both panels open
+  it('initializes with both panels open', () => {
+    const state = useUiStore.getState()
+    expect(state.leftPanelOpen).toBe(true)
+    expect(state.rightPanelOpen).toBe(true)
+  })
+
+  // Edge case 1: toggleLeftPanel closes the left panel
+  it('toggleLeftPanel closes an open left panel', () => {
+    const { toggleLeftPanel } = useUiStore.getState()
+    toggleLeftPanel()
+    expect(useUiStore.getState().leftPanelOpen).toBe(false)
+  })
+
+  // Edge case 2: toggleRightPanel closes the right panel
+  it('toggleRightPanel closes an open right panel', () => {
+    const { toggleRightPanel } = useUiStore.getState()
+    toggleRightPanel()
+    expect(useUiStore.getState().rightPanelOpen).toBe(false)
+  })
+
+  // Edge case 3: collapsing both panels leaves both closed
+  it('both panels can be collapsed independently', () => {
+    const store = useUiStore.getState()
+    store.toggleLeftPanel()
+    store.toggleRightPanel()
+    const state = useUiStore.getState()
+    expect(state.leftPanelOpen).toBe(false)
+    expect(state.rightPanelOpen).toBe(false)
+  })
+
+  // Edge case 4: toggle twice returns to original state
+  it('double-toggle restores panel to open state', () => {
+    const store = useUiStore.getState()
+    store.toggleLeftPanel()
+    useUiStore.getState().toggleLeftPanel()
+    expect(useUiStore.getState().leftPanelOpen).toBe(true)
+  })
+
+  // Edge case 5: setLeftPanel explicitly sets panel state
+  it('setLeftPanel can set state explicitly', () => {
+    const { setLeftPanel } = useUiStore.getState()
+    setLeftPanel(false)
+    expect(useUiStore.getState().leftPanelOpen).toBe(false)
+    setLeftPanel(true)
+    expect(useUiStore.getState().leftPanelOpen).toBe(true)
+  })
+
+  // Edge case 6: setRightPanel explicitly sets panel state
+  it('setRightPanel can set state explicitly', () => {
+    const { setRightPanel } = useUiStore.getState()
+    setRightPanel(false)
+    expect(useUiStore.getState().rightPanelOpen).toBe(false)
+    setRightPanel(true)
+    expect(useUiStore.getState().rightPanelOpen).toBe(true)
+  })
+})

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,16 +1,6 @@
 import React from 'react'
-import NodeCanvas from './components/NodeCanvas'
-import Toolbar from './components/Toolbar'
-import StatusBar from './components/StatusBar'
+import Layout from './components/Layout'
 
 export default function App(): React.JSX.Element {
-  return (
-    <div className="flex flex-col h-screen w-screen bg-canvas-bg text-white overflow-hidden">
-      <Toolbar />
-      <main className="flex-1 relative overflow-hidden">
-        <NodeCanvas />
-      </main>
-      <StatusBar />
-    </div>
-  )
+  return <Layout />
 }

--- a/src/renderer/src/components/Canvas.tsx
+++ b/src/renderer/src/components/Canvas.tsx
@@ -1,0 +1,63 @@
+import React, { useCallback } from 'react'
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  Connection,
+  addEdge
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import { useFlowStore } from '../store/flow-store'
+import ImageSourceNode from './nodes/ImageSourceNode'
+import FilterNode from './nodes/FilterNode'
+import OutputNode from './nodes/OutputNode'
+
+const nodeTypes = {
+  imageSource: ImageSourceNode,
+  filter: FilterNode,
+  output: OutputNode
+}
+
+const SNAP_GRID: [number, number] = [16, 16]
+
+export default function Canvas(): React.JSX.Element {
+  const { nodes, edges, onNodesChange, onEdgesChange, setEdges } = useFlowStore()
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      setEdges(eds => addEdge(connection, eds))
+    },
+    [setEdges]
+  )
+
+  return (
+    <div className="w-full h-full" data-testid="canvas">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        nodeTypes={nodeTypes}
+        fitView
+        colorMode="dark"
+        snapToGrid
+        snapGrid={SNAP_GRID}
+        className="bg-canvas-bg"
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.1}
+        maxZoom={4}
+      >
+        <Background variant={BackgroundVariant.Dots} gap={16} size={1} color="#313244" />
+        <Controls showInteractive={false} />
+        <MiniMap
+          nodeColor="#313244"
+          maskColor="rgba(26, 26, 46, 0.8)"
+          style={{ background: '#1e1e2e' }}
+        />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/src/renderer/src/components/Layout.tsx
+++ b/src/renderer/src/components/Layout.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { useUiStore } from '../store/ui-store'
+import NodePalette from './NodePalette'
+import Canvas from './Canvas'
+import PropertiesPanel from './PropertiesPanel'
+import StatusBar from './StatusBar'
+
+const LEFT_PANEL_WIDTH = 250
+const RIGHT_PANEL_WIDTH = 300
+
+function PanelToggleButton({
+  side,
+  isOpen,
+  onToggle
+}: {
+  side: 'left' | 'right'
+  isOpen: boolean
+  onToggle: () => void
+}): React.JSX.Element {
+  const label = side === 'left' ? (isOpen ? '‹' : '›') : isOpen ? '›' : '‹'
+  const title = `${isOpen ? 'Collapse' : 'Expand'} ${side} panel`
+
+  return (
+    <button
+      onClick={onToggle}
+      title={title}
+      aria-label={title}
+      className="absolute top-1/2 -translate-y-1/2 z-10 w-4 h-8 flex items-center justify-center
+                 bg-canvas-surface border border-canvas-border text-gray-400
+                 hover:text-white hover:bg-node-header transition-colors rounded-sm text-xs"
+      style={{ [side === 'left' ? 'right' : 'left']: '-8px' }}
+    >
+      {label}
+    </button>
+  )
+}
+
+function LeftPanel({ isOpen }: { isOpen: boolean }): React.JSX.Element {
+  const { toggleLeftPanel } = useUiStore()
+
+  return (
+    <aside
+      data-testid="left-panel"
+      className="relative flex-shrink-0 border-r border-canvas-border bg-canvas-surface
+                 transition-all duration-200 overflow-hidden"
+      style={{ width: isOpen ? LEFT_PANEL_WIDTH : 0 }}
+    >
+      {isOpen && <NodePalette />}
+      <PanelToggleButton side="left" isOpen={isOpen} onToggle={toggleLeftPanel} />
+    </aside>
+  )
+}
+
+function RightPanel({ isOpen }: { isOpen: boolean }): React.JSX.Element {
+  const { toggleRightPanel } = useUiStore()
+
+  return (
+    <aside
+      data-testid="right-panel"
+      className="relative flex-shrink-0 border-l border-canvas-border bg-canvas-surface
+                 transition-all duration-200 overflow-hidden"
+      style={{ width: isOpen ? RIGHT_PANEL_WIDTH : 0 }}
+    >
+      {isOpen && <PropertiesPanel />}
+      <PanelToggleButton side="right" isOpen={isOpen} onToggle={toggleRightPanel} />
+    </aside>
+  )
+}
+
+export default function Layout(): React.JSX.Element {
+  const { leftPanelOpen, rightPanelOpen } = useUiStore()
+
+  return (
+    <div className="flex flex-col h-screen w-screen bg-canvas-bg text-white overflow-hidden">
+      <main className="flex flex-1 overflow-hidden" data-testid="main-panels">
+        <LeftPanel isOpen={leftPanelOpen} />
+        <section className="flex-1 relative overflow-hidden" data-testid="canvas-container">
+          <Canvas />
+        </section>
+        <RightPanel isOpen={rightPanelOpen} />
+      </main>
+      <StatusBar />
+    </div>
+  )
+}

--- a/src/renderer/src/components/NodePalette.tsx
+++ b/src/renderer/src/components/NodePalette.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { useFlowStore } from '../store/flow-store'
+import type { NodeType } from '../../../shared/types'
+
+interface PaletteItem {
+  type: NodeType
+  label: string
+  icon: string
+  description: string
+}
+
+const PALETTE_ITEMS: PaletteItem[] = [
+  {
+    type: 'imageSource',
+    label: 'Image Source',
+    icon: '▲',
+    description: 'Load an image from disk'
+  },
+  {
+    type: 'filter',
+    label: 'Filter',
+    icon: '◈',
+    description: 'Apply image filters'
+  },
+  {
+    type: 'output',
+    label: 'Output',
+    icon: '■',
+    description: 'Export the result'
+  }
+]
+
+function PaletteItem({ item }: { item: PaletteItem }): React.JSX.Element {
+  const { addNode } = useFlowStore()
+
+  return (
+    <button
+      className="w-full text-left px-3 py-2 rounded-md bg-node-bg border border-node-border
+                 hover:border-node-selected hover:bg-node-header transition-colors group"
+      onClick={() => addNode(item.type)}
+      title={item.description}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-blue-400 text-sm">{item.icon}</span>
+        <div>
+          <p className="text-xs font-medium text-white">{item.label}</p>
+          <p className="text-[10px] text-gray-500 group-hover:text-gray-400">
+            {item.description}
+          </p>
+        </div>
+      </div>
+    </button>
+  )
+}
+
+export default function NodePalette(): React.JSX.Element {
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="px-3 py-2 border-b border-canvas-border">
+        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+          Node Palette
+        </h2>
+      </div>
+      <div className="flex-1 overflow-y-auto p-2 space-y-1">
+        {PALETTE_ITEMS.map(item => (
+          <PaletteItem key={item.type} item={item} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/PropertiesPanel.tsx
+++ b/src/renderer/src/components/PropertiesPanel.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function PropertiesPanel(): React.JSX.Element {
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="px-3 py-2 border-b border-canvas-border">
+        <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+          Properties
+        </h2>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3">
+        <p className="text-xs text-gray-500 text-center mt-4">
+          Select a node to view its properties
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/store/ui-store.ts
+++ b/src/renderer/src/store/ui-store.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand'
+
+interface UiState {
+  leftPanelOpen: boolean
+  rightPanelOpen: boolean
+  toggleLeftPanel: () => void
+  toggleRightPanel: () => void
+  setLeftPanel: (open: boolean) => void
+  setRightPanel: (open: boolean) => void
+}
+
+export const useUiStore = create<UiState>(set => ({
+  leftPanelOpen: true,
+  rightPanelOpen: true,
+
+  toggleLeftPanel: () => set(state => ({ leftPanelOpen: !state.leftPanelOpen })),
+  toggleRightPanel: () => set(state => ({ rightPanelOpen: !state.rightPanelOpen })),
+
+  setLeftPanel: (open: boolean) => set({ leftPanelOpen: open }),
+  setRightPanel: (open: boolean) => set({ rightPanelOpen: open })
+}))


### PR DESCRIPTION
## Summary

Implements the weavy.ai-inspired three-panel layout for the node-based image generation app. Adds a collapsible left sidebar (node palette), a center React Flow canvas with dark mode and snap-to-grid, and a collapsible right properties panel. Panel visibility state is managed via a new Zustand `useUiStore`.

## Changes

- `src/renderer/src/store/ui-store.ts` — New Zustand store managing left/right panel open state with toggle and set actions
- `src/renderer/src/components/Layout.tsx` — Three-panel flexbox layout with animated panel collapse via CSS transition; replaces old Toolbar+NodeCanvas+StatusBar arrangement
- `src/renderer/src/components/Canvas.tsx` — Dedicated canvas component wrapping ReactFlow with `colorMode="dark"`, `<MiniMap>`, `<Controls>`, `<Background variant="dots">`, snap-to-grid (16px), zoom, and pan
- `src/renderer/src/components/NodePalette.tsx` — Left sidebar shell with clickable node type palette items (image source, filter, output)
- `src/renderer/src/components/PropertiesPanel.tsx` — Right panel shell showing placeholder until a node is selected
- `src/renderer/src/App.tsx` — Simplified to delegate entirely to `<Layout />`
- `src/__tests__/ui-store.test.ts` — 7 unit tests for panel toggle/set state logic
- `src/__tests__/layout-state.test.ts` — 4 unit tests covering panel width computation (happy path + 3 edge cases)

## Test Plan

- Run `npm test` — 26 tests pass (11 new + 15 existing)
- Run `bash scripts/ci-lint.sh` — ESLint passes
- Run `bash scripts/ci-file-size.sh` — All files under 800 lines
- Launch `npm run dev` to verify: three-panel layout renders, minimap/controls visible, panels collapse via toggle buttons, canvas fills space when panels closed

Fixes #25