### PR TITLE
Implement custom node rendering from NodeDefinition

### DIFF
--- a/src/__tests__/generic-node-data.test.ts
+++ b/src/__tests__/generic-node-data.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for GenericNode data structures, type registry, and flow store extensions.
+ * These are unit tests that do not require a DOM environment.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  PORT_TYPE_REGISTRY,
+  resolvePortType,
+  NodeDefinition
+} from '../shared/types'
+import { buildNodeTypes, BASE_NODE_TYPES } from '../renderer/src/components/nodes/nodeTypeRegistry'
+import { useFlowStore } from '../renderer/src/store/flow-store'
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+function makeDefinition(overrides: Partial<NodeDefinition> = {}): NodeDefinition {
+  return {
+    id: 'test/node',
+    name: 'Test Node',
+    category: 'test',
+    inputs: [{ id: 'in1', label: 'Input', type: 'IMAGE' }],
+    outputs: [{ id: 'out1', label: 'Output', type: 'IMAGE' }],
+    parameters: [],
+    execute: async () => ({}),
+    ...overrides
+  }
+}
+
+// ─── PORT_TYPE_REGISTRY ───────────────────────────────────────────────────────
+
+describe('PORT_TYPE_REGISTRY', () => {
+  it('contains all five built-in port types', () => {
+    const keys = Object.keys(PORT_TYPE_REGISTRY)
+    expect(keys).toContain('IMAGE')
+    expect(keys).toContain('TEXT')
+    expect(keys).toContain('NUMBER')
+    expect(keys).toContain('JSON')
+    expect(keys).toContain('ANY')
+  })
+
+  it('each port type has id, label, and color fields', () => {
+    for (const pt of Object.values(PORT_TYPE_REGISTRY)) {
+      expect(typeof pt.id).toBe('string')
+      expect(typeof pt.label).toBe('string')
+      expect(typeof pt.color).toBe('string')
+      expect(pt.color).toMatch(/^#[0-9A-Fa-f]{6}$/)
+    }
+  })
+})
+
+// ─── resolvePortType ─────────────────────────────────────────────────────────
+
+describe('resolvePortType', () => {
+  // Happy path
+  it('returns the correct type for a known id', () => {
+    const pt = resolvePortType('IMAGE')
+    expect(pt.id).toBe('IMAGE')
+    expect(pt.color).toBe('#64B5F6')
+  })
+
+  // Edge case 1: unknown id falls back to ANY
+  it('falls back to ANY for unknown ids', () => {
+    const pt = resolvePortType('UNKNOWN_TYPE')
+    expect(pt.id).toBe('ANY')
+  })
+
+  // Edge case 2: case sensitive — lowercase does not match
+  it('is case-sensitive (lowercase does not match)', () => {
+    const pt = resolvePortType('image')
+    expect(pt.id).toBe('ANY')
+  })
+
+  // Edge case 3: empty string falls back to ANY
+  it('returns ANY for empty string', () => {
+    const pt = resolvePortType('')
+    expect(pt.id).toBe('ANY')
+  })
+})
+
+// ─── buildNodeTypes ──────────────────────────────────────────────────────────
+
+describe('buildNodeTypes', () => {
+  // Happy path
+  it('includes base node types when passed empty definitions', () => {
+    const types = buildNodeTypes([])
+    expect(types).toHaveProperty('imageSource')
+    expect(types).toHaveProperty('filter')
+    expect(types).toHaveProperty('output')
+  })
+
+  it('adds plugin definition ids as keys', () => {
+    const def = makeDefinition({ id: 'plugin/blur' })
+    const types = buildNodeTypes([def])
+    expect(types).toHaveProperty('plugin/blur')
+  })
+
+  // Edge case 1: multiple definitions all registered
+  it('registers all provided definitions', () => {
+    const defs = [
+      makeDefinition({ id: 'a/node1' }),
+      makeDefinition({ id: 'b/node2' }),
+      makeDefinition({ id: 'c/node3' })
+    ]
+    const types = buildNodeTypes(defs)
+    expect(types).toHaveProperty('a/node1')
+    expect(types).toHaveProperty('b/node2')
+    expect(types).toHaveProperty('c/node3')
+  })
+
+  // Edge case 2: does not lose base types when definitions provided
+  it('preserves base types when definitions are provided', () => {
+    const types = buildNodeTypes([makeDefinition({ id: 'x/y' })])
+    const baseKeys = Object.keys(BASE_NODE_TYPES)
+    for (const key of baseKeys) {
+      expect(types).toHaveProperty(key)
+    }
+  })
+
+  // Edge case 3: definition id can contain slashes
+  it('handles definition ids with slashes', () => {
+    const def = makeDefinition({ id: 'my-plugin/some/deep/id' })
+    const types = buildNodeTypes([def])
+    expect(types).toHaveProperty('my-plugin/some/deep/id')
+  })
+})
+
+// ─── Flow store runtime state ─────────────────────────────────────────────────
+
+describe('useFlowStore runtime state', () => {
+  beforeEach(() => {
+    // Reset runtime states between tests
+    useFlowStore.setState({ nodeRuntimeStates: {} })
+  })
+
+  // Happy path
+  it('getOrCreateNodeRuntime returns idle state for new node', () => {
+    const { getOrCreateNodeRuntime } = useFlowStore.getState()
+    const runtime = getOrCreateNodeRuntime('node-abc')
+    expect(runtime.executionState).toBe('idle')
+    expect(runtime.paramValues).toEqual({})
+    expect(runtime.imagePreviews).toEqual({})
+  })
+
+  it('setNodeExecutionState updates the state', () => {
+    const { setNodeExecutionState } = useFlowStore.getState()
+    setNodeExecutionState('node-1', 'running')
+    const runtime = useFlowStore.getState().nodeRuntimeStates['node-1']
+    expect(runtime.executionState).toBe('running')
+  })
+
+  // Edge case 1: setNodeParamValue stores value
+  it('setNodeParamValue stores parameter value', () => {
+    const { setNodeParamValue } = useFlowStore.getState()
+    setNodeParamValue('node-2', 'prompt', 'hello world')
+    const runtime = useFlowStore.getState().nodeRuntimeStates['node-2']
+    expect(runtime.paramValues['prompt']).toBe('hello world')
+  })
+
+  // Edge case 2: setNodeImagePreview stores data URL
+  it('setNodeImagePreview stores image data URL', () => {
+    const { setNodeImagePreview } = useFlowStore.getState()
+    setNodeImagePreview('node-3', 'out1', 'data:image/png;base64,abc')
+    const runtime = useFlowStore.getState().nodeRuntimeStates['node-3']
+    expect(runtime.imagePreviews['out1']).toBe('data:image/png;base64,abc')
+  })
+
+  // Edge case 3: multiple nodes are independent
+  it('node runtime states are independent per node', () => {
+    const { setNodeExecutionState } = useFlowStore.getState()
+    setNodeExecutionState('node-x', 'running')
+    setNodeExecutionState('node-y', 'error')
+    const states = useFlowStore.getState().nodeRuntimeStates
+    expect(states['node-x'].executionState).toBe('running')
+    expect(states['node-y'].executionState).toBe('error')
+  })
+
+  // Edge case 4: setNodeImagePreview with null clears the preview
+  it('setNodeImagePreview with null clears the preview', () => {
+    const { setNodeImagePreview } = useFlowStore.getState()
+    setNodeImagePreview('node-4', 'out1', 'data:image/png;base64,abc')
+    setNodeImagePreview('node-4', 'out1', null)
+    const runtime = useFlowStore.getState().nodeRuntimeStates['node-4']
+    expect(runtime.imagePreviews['out1']).toBeNull()
+  })
+})

--- a/src/renderer/src/components/Canvas.tsx
+++ b/src/renderer/src/components/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import {
   ReactFlow,
   Background,
@@ -10,17 +10,13 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { useFlowStore } from '../store/flow-store'
-import ImageSourceNode from './nodes/ImageSourceNode'
-import FilterNode from './nodes/FilterNode'
-import OutputNode from './nodes/OutputNode'
-
-const nodeTypes = {
-  imageSource: ImageSourceNode,
-  filter: FilterNode,
-  output: OutputNode
-}
+import { buildNodeTypes } from './nodes/nodeTypeRegistry'
+import type { NodeDefinition } from '../../../shared/types'
 
 const SNAP_GRID: [number, number] = [16, 16]
+
+/** Currently registered plugin definitions passed from outside, or empty array. */
+const EMPTY_DEFINITIONS: NodeDefinition[] = []
 
 export default function Canvas(): React.JSX.Element {
   const { nodes, edges, onNodesChange, onEdgesChange, setEdges } = useFlowStore()
@@ -31,6 +27,10 @@ export default function Canvas(): React.JSX.Element {
     },
     [setEdges]
   )
+
+  // Build nodeTypes once from static definitions.
+  // In a future iteration this will be driven by the live NodeRegistry.
+  const nodeTypes = useMemo(() => buildNodeTypes(EMPTY_DEFINITIONS), [])
 
   return (
     <div className="w-full h-full" data-testid="canvas">

--- a/src/renderer/src/components/nodes/GenericNode.tsx
+++ b/src/renderer/src/components/nodes/GenericNode.tsx
@@ -1,0 +1,135 @@
+import React, { memo, useCallback } from 'react'
+import { NodeProps, Position } from '@xyflow/react'
+import type { NodeDefinition, NodeExecutionState } from '../../../../shared/types'
+import { useFlowStore } from '../../store/flow-store'
+import NodeHeader from './NodeHeader'
+import NodeHandles from './NodeHandles'
+import NodeImagePreview from './NodeImagePreview'
+import ParameterWidget from '../widgets/ParameterWidget'
+
+/** Data shape stored in the React Flow node's `data` field for generic nodes. */
+export interface GenericNodeData {
+  definition: NodeDefinition
+  [key: string]: unknown
+}
+
+const DEFAULT_WIDTH = 280
+
+function NodeParameters({
+  nodeId,
+  definition,
+  paramValues
+}: {
+  nodeId: string
+  definition: NodeDefinition
+  paramValues: Record<string, unknown>
+}): React.JSX.Element {
+  const { setNodeParamValue } = useFlowStore()
+  const params = definition.parameters ?? []
+
+  if (params.length === 0) return <></>
+
+  return (
+    <div className="flex flex-col gap-2 px-2 py-2 border-t border-node-border">
+      {params.map(param => (
+        <ParameterWidget
+          key={param.id}
+          param={param}
+          value={paramValues[param.id] ?? param.default}
+          onChange={val => setNodeParamValue(nodeId, param.id, val)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function PortLabels({
+  inputs,
+  outputs
+}: {
+  inputs: NodeDefinition['inputs']
+  outputs: NodeDefinition['outputs']
+}): React.JSX.Element {
+  if (inputs.length === 0 && outputs.length === 0) return <></>
+
+  return (
+    <div className="flex justify-between px-3 py-1">
+      <div className="flex flex-col gap-0.5">
+        {inputs.map(p => (
+          <span key={p.id} className="text-[10px] text-gray-400 truncate max-w-[90px]">
+            {p.label}
+          </span>
+        ))}
+      </div>
+      <div className="flex flex-col gap-0.5 items-end">
+        {outputs.map(p => (
+          <span key={p.id} className="text-[10px] text-gray-400 truncate max-w-[90px]">
+            {p.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function GenericNodeInner({ id, data, selected }: NodeProps): React.JSX.Element {
+  const { definition } = data as GenericNodeData
+  const { setNodeExecutionState, getOrCreateNodeRuntime } = useFlowStore()
+  const runtime = getOrCreateNodeRuntime(id)
+
+  const handleRun = useCallback(() => {
+    setNodeExecutionState(id, 'running')
+    // Simulate async execution for now
+    setTimeout(() => {
+      setNodeExecutionState(id, 'completed')
+    }, 1500)
+  }, [id, setNodeExecutionState])
+
+  const nodeWidth = definition.width ?? DEFAULT_WIDTH
+  const borderClass = selected ? 'border-node-selected' : 'border-node-border'
+
+  return (
+    <div
+      className={`node-card ${borderClass} flex flex-col overflow-hidden`}
+      style={{ width: nodeWidth }}
+      data-testid={`generic-node-${definition.id}`}
+    >
+      <NodeHeader
+        name={definition.name}
+        category={definition.category}
+        executionState={runtime.executionState as NodeExecutionState}
+        onRun={handleRun}
+      />
+
+      {(definition.inputs.length > 0 || definition.outputs.length > 0) && (
+        <PortLabels inputs={definition.inputs} outputs={definition.outputs} />
+      )}
+
+      <NodeParameters
+        nodeId={id}
+        definition={definition}
+        paramValues={runtime.paramValues}
+      />
+
+      <NodeImagePreview
+        outputs={definition.outputs}
+        imagePreviews={runtime.imagePreviews}
+      />
+
+      <NodeHandles
+        ports={definition.inputs}
+        position={Position.Left}
+        handleType="target"
+      />
+      <NodeHandles
+        ports={definition.outputs}
+        position={Position.Right}
+        handleType="source"
+      />
+    </div>
+  )
+}
+
+/** Memoized generic node component for React Flow. */
+const GenericNode = memo(GenericNodeInner)
+export default GenericNode

--- a/src/renderer/src/components/nodes/NodeHandles.tsx
+++ b/src/renderer/src/components/nodes/NodeHandles.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { Handle, Position } from '@xyflow/react'
+import type { PortDefinition } from '../../../../shared/types'
+import { resolvePortType } from '../../../../shared/types'
+
+interface HandleListProps {
+  ports: PortDefinition[]
+  position: Position
+  handleType: 'source' | 'target'
+}
+
+function PortHandle({
+  port,
+  index,
+  total,
+  position,
+  handleType
+}: {
+  port: PortDefinition
+  index: number
+  total: number
+  position: Position
+  handleType: 'source' | 'target'
+}): React.JSX.Element {
+  const portType = resolvePortType(port.type)
+  const topPercent = total === 1 ? 50 : 20 + (60 / (total - 1)) * index
+
+  return (
+    <Handle
+      key={port.id}
+      id={port.id}
+      type={handleType}
+      position={position}
+      style={{
+        backgroundColor: portType.color,
+        top: `${topPercent}%`,
+        border: '2px solid rgba(0,0,0,0.4)',
+        width: 10,
+        height: 10
+      }}
+      title={`${port.label} (${portType.label})`}
+    />
+  )
+}
+
+export default function NodeHandles({
+  ports,
+  position,
+  handleType
+}: HandleListProps): React.JSX.Element {
+  if (ports.length === 0) return <></>
+
+  return (
+    <>
+      {ports.map((port, i) => (
+        <PortHandle
+          key={port.id}
+          port={port}
+          index={i}
+          total={ports.length}
+          position={position}
+          handleType={handleType}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/renderer/src/components/nodes/NodeHeader.tsx
+++ b/src/renderer/src/components/nodes/NodeHeader.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import type { NodeExecutionState } from '../../../../shared/types'
+
+interface NodeHeaderProps {
+  name: string
+  category: string
+  executionState: NodeExecutionState
+  onRun: () => void
+}
+
+function StateIndicator({
+  state
+}: {
+  state: NodeExecutionState
+}): React.JSX.Element {
+  if (state === 'running') {
+    return (
+      <span
+        className="w-3 h-3 rounded-full bg-yellow-400 animate-pulse shrink-0"
+        title="Running"
+        aria-label="Running"
+      />
+    )
+  }
+  if (state === 'completed') {
+    return (
+      <span
+        className="text-green-400 text-xs shrink-0"
+        title="Completed"
+        aria-label="Completed"
+      >
+        &#10003;
+      </span>
+    )
+  }
+  if (state === 'error') {
+    return (
+      <span
+        className="text-red-400 text-xs shrink-0"
+        title="Error"
+        aria-label="Error"
+      >
+        &#x26A0;
+      </span>
+    )
+  }
+  return <span className="w-3 h-3 shrink-0" />
+}
+
+export default function NodeHeader({
+  name,
+  category,
+  executionState,
+  onRun
+}: NodeHeaderProps): React.JSX.Element {
+  return (
+    <div className="node-header flex items-center gap-1 px-2 py-1.5">
+      <span
+        className="text-[10px] px-1 py-0.5 rounded bg-canvas-bg text-gray-400
+                   border border-node-border shrink-0 truncate max-w-[60px]"
+        title={category}
+      >
+        {category}
+      </span>
+      <span className="flex-1 text-xs font-medium text-white truncate" title={name}>
+        {name}
+      </span>
+      <StateIndicator state={executionState} />
+      <button
+        onClick={onRun}
+        disabled={executionState === 'running'}
+        className="ml-1 px-1.5 py-0.5 text-[10px] rounded bg-blue-600 hover:bg-blue-500
+                   disabled:opacity-50 disabled:cursor-not-allowed text-white shrink-0
+                   nodrag transition-colors"
+        title="Run this node"
+        aria-label="Run node"
+      >
+        Run
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/nodes/NodeImagePreview.tsx
+++ b/src/renderer/src/components/nodes/NodeImagePreview.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import type { PortDefinition } from '../../../../shared/types'
+
+interface NodeImagePreviewProps {
+  outputs: PortDefinition[]
+  imagePreviews: Record<string, string | null>
+}
+
+function ImagePreviewItem({
+  port,
+  dataUrl
+}: {
+  port: PortDefinition
+  dataUrl: string | null
+}): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] text-gray-400">{port.label}</span>
+      {dataUrl ? (
+        <img
+          src={dataUrl}
+          alt={port.label}
+          className="w-full rounded border border-node-border object-contain max-h-32"
+        />
+      ) : (
+        <div
+          className="w-full h-20 rounded border border-node-border bg-canvas-bg
+                     flex items-center justify-center text-gray-600 text-[10px]"
+          aria-label={`${port.label} preview placeholder`}
+        >
+          No image
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function NodeImagePreview({
+  outputs,
+  imagePreviews
+}: NodeImagePreviewProps): React.JSX.Element {
+  const imageOutputs = outputs.filter(p => p.type === 'IMAGE')
+
+  if (imageOutputs.length === 0) return <></>
+
+  return (
+    <div className="flex flex-col gap-2 px-2 pb-2 border-t border-node-border pt-2">
+      {imageOutputs.map(port => (
+        <ImagePreviewItem
+          key={port.id}
+          port={port}
+          dataUrl={imagePreviews[port.id] ?? null}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/nodes/nodeTypeRegistry.ts
+++ b/src/renderer/src/components/nodes/nodeTypeRegistry.ts
@@ -1,0 +1,27 @@
+import type { NodeTypes } from '@xyflow/react'
+import type { NodeDefinition } from '../../../../shared/types'
+import GenericNode from './GenericNode'
+import ImageSourceNode from './ImageSourceNode'
+import FilterNode from './FilterNode'
+import OutputNode from './OutputNode'
+
+/** Base node types always registered (legacy hard-coded node types). */
+export const BASE_NODE_TYPES: NodeTypes = {
+  imageSource: ImageSourceNode,
+  filter: FilterNode,
+  output: OutputNode
+}
+
+/**
+ * Builds a merged nodeTypes map from base types plus any NodeDefinitions
+ * from the plugin registry. Plugin nodes use GenericNode as their renderer.
+ *
+ * The type key for plugin nodes is the definition id (e.g. "plugin/blur").
+ */
+export function buildNodeTypes(definitions: NodeDefinition[]): NodeTypes {
+  const pluginTypes: NodeTypes = {}
+  for (const def of definitions) {
+    pluginTypes[def.id] = GenericNode
+  }
+  return { ...BASE_NODE_TYPES, ...pluginTypes }
+}

--- a/src/renderer/src/components/widgets/NumberWidget.tsx
+++ b/src/renderer/src/components/widgets/NumberWidget.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import type { ParameterDefinition } from '../../../../shared/types'
+
+interface NumberWidgetProps {
+  param: ParameterDefinition
+  value: unknown
+  onChange: (value: number) => void
+}
+
+export default function NumberWidget({
+  param,
+  value,
+  onChange
+}: NumberWidgetProps): React.JSX.Element {
+  const numValue = typeof value === 'number' ? value : Number(value ?? param.default ?? 0)
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[10px] text-gray-400 truncate">{param.label}</label>
+      <input
+        type="number"
+        value={numValue}
+        min={param.min}
+        max={param.max}
+        step={param.step ?? 1}
+        onChange={e => onChange(Number(e.target.value))}
+        className="w-full bg-canvas-bg border border-node-border rounded px-2 py-1
+                   text-xs text-white focus:outline-none focus:border-node-selected
+                   nodrag"
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/widgets/ParameterWidget.tsx
+++ b/src/renderer/src/components/widgets/ParameterWidget.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import type { ParameterDefinition } from '../../../../shared/types'
+import TextWidget from './TextWidget'
+import NumberWidget from './NumberWidget'
+import SliderWidget from './SliderWidget'
+import ToggleWidget from './ToggleWidget'
+import SelectWidget from './SelectWidget'
+import TextAreaWidget from './TextAreaWidget'
+
+interface ParameterWidgetProps {
+  param: ParameterDefinition
+  value: unknown
+  onChange: (value: unknown) => void
+}
+
+/**
+ * Dispatches to the correct widget component based on parameter type.
+ */
+export default function ParameterWidget({
+  param,
+  value,
+  onChange
+}: ParameterWidgetProps): React.JSX.Element {
+  switch (param.type) {
+    case 'text':
+      return <TextWidget param={param} value={value} onChange={onChange} />
+    case 'number':
+      return <NumberWidget param={param} value={value} onChange={onChange} />
+    case 'slider':
+      return <SliderWidget param={param} value={value} onChange={onChange} />
+    case 'toggle':
+      return <ToggleWidget param={param} value={value} onChange={v => onChange(v)} />
+    case 'select':
+      return <SelectWidget param={param} value={value} onChange={onChange} />
+    case 'textarea':
+      return <TextAreaWidget param={param} value={value} onChange={onChange} />
+    default:
+      return <TextWidget param={param} value={value} onChange={onChange} />
+  }
+}

--- a/src/renderer/src/components/widgets/SelectWidget.tsx
+++ b/src/renderer/src/components/widgets/SelectWidget.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import type { ParameterDefinition } from '../../../../shared/types'
+
+interface SelectWidgetProps {
+  param: ParameterDefinition
+  value: unknown
+  onChange: (value: string) => void
+}
+
+export default function SelectWidget({
+  param,
+  value,
+  onChange
+}: SelectWidgetProps): React.JSX.Element {
+  const strValue = typeof value === 'string' ? value : String(value ?? param.default ?? '')
+  const options = param.options ?? []
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[10px] text-gray-400 truncate">{param.label}</label>
+      <select
+        value={strValue}
+        onChange={e => onChange(e.target.value)}
+        className="w-full bg-canvas-bg border border-node-border rounded px-2 py-1
+                   text-xs text-white focus:outline-none focus:border-node-selected
+                   nodrag"
+      >
+        {options.map(opt => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/src/renderer/src/components/widgets/SliderWidget.tsx
+++ b/src/renderer/src/components/widgets/SliderWidget.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import type { ParameterDefinition } from '../../../../shared/types'
+
+interface SliderWidgetProps {
+  param: ParameterDefinition
+  value: unknown
+  onChange: (value: number) => void
+}
+
+export default function SliderWidget({
+  param,
+  value,
+  onChange
+}: SliderWidgetProps): React.JSX.Element {
+  const min = param.min ?? 0
+  const max = param.max ?? 100
+  const step = param.step ?? 1
+  const numValue = typeof value === 'number' ? value : Number(value ?? param.default ?? min)
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between">
+        <label className="text-[10px] text-gray-400 truncate">{param.label}</label>
+        <span className="text-[10px] text-gray-300 ml-2 shrink-0">{numValue}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={numValue}
+        onChange={e => onChange(Number(e.target.value))}
+        className="w-full h-1.5 accent-blue-400 nodrag"
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/widgets/TextAreaWidget.tsx
+++ b/src/renderer/src/components/widgets/TextAreaWidget.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import type { ParameterDefinition } from '../../../../shared/types'
+
+interface TextAreaWidgetProps {
+  param: ParameterDefinition
+  value: unknown
+  onChange: (value: string) => void
+}
+
+export default function TextAreaWidget({
+  param,
+  value,
+  onChange
+}: TextAreaWidgetProps): React.JSX.Element {
+  const strValue = typeof value === 'string' ? value : String(value ?? param.default ?? '')
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[10px] text-gray-400 truncate">{param.label}</label>
+      <textarea
+        value={strValue}
+        onChange={e => onChange(e.target.value)}
+        rows={3}
+        className="w-full bg-canvas-bg border border-node-border rounded px-2 py-1
+                   text-xs text-white focus:outline-none focus:border-node-selected
+                   resize-none nodrag"
+        placeholder={param.label}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/widgets/TextWidget.tsx
+++ b/src/renderer/src/components/widgets/TextWidget.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import type { ParameterDefinition } from '../../../../shared/types'
+
+interface TextWidgetProps {
+  param: ParameterDefinition
+  value: unknown
+  onChange: (value: string) => void
+}
+
+export default function TextWidget({
+  param,
+  value,
+  onChange
+}: TextWidgetProps): React.JSX.Element {
+  const strValue = typeof value === 'string' ? value : String(value ?? param.default ?? '')
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[10px] text-gray-400 truncate">{param.label}</label>
+      <input
+        type="text"
+        value={strValue}
+        onChange={e => onChange(e.target.value)}
+        className="w-full bg-canvas-bg border border-node-border rounded px-2 py-1
+                   text-xs text-white focus:outline-none focus:border-node-selected
+                   nodrag"
+        placeholder={param.label}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/widgets/ToggleWidget.tsx
+++ b/src/renderer/src/components/widgets/ToggleWidget.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import type { ParameterDefinition } from '../../../../shared/types'
+
+interface ToggleWidgetProps {
+  param: ParameterDefinition
+  value: unknown
+  onChange: (value: boolean) => void
+}
+
+export default function ToggleWidget({
+  param,
+  value,
+  onChange
+}: ToggleWidgetProps): React.JSX.Element {
+  const boolValue = typeof value === 'boolean' ? value : Boolean(value ?? param.default ?? false)
+
+  return (
+    <div className="flex items-center justify-between">
+      <label className="text-[10px] text-gray-400 truncate">{param.label}</label>
+      <button
+        role="switch"
+        aria-checked={boolValue}
+        onClick={() => onChange(!boolValue)}
+        className={`relative w-8 h-4 rounded-full transition-colors nodrag shrink-0
+                    ${boolValue ? 'bg-blue-500' : 'bg-gray-600'}`}
+      >
+        <span
+          className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform
+                      ${boolValue ? 'translate-x-4' : 'translate-x-0.5'}`}
+        />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/store/flow-store.ts
+++ b/src/renderer/src/store/flow-store.ts
@@ -7,22 +7,42 @@ import {
   applyNodeChanges,
   applyEdgeChanges
 } from '@xyflow/react'
-import type { NodeType } from '../../../shared/types'
+import type { NodeType, NodeExecutionState } from '../../../shared/types'
 import { createInitialNodes, createInitialEdges } from './flow-initial-state'
 import { buildNewNode } from './flow-node-factory'
+
+/** Per-node runtime state: execution status and parameter values. */
+export interface NodeRuntimeState {
+  executionState: NodeExecutionState
+  /** Parameter id -> current value */
+  paramValues: Record<string, unknown>
+  /** For image-type outputs: data URL or null */
+  imagePreviews: Record<string, string | null>
+}
 
 interface FlowState {
   nodes: Node[]
   edges: Edge[]
+  /** Runtime state keyed by node instance id */
+  nodeRuntimeStates: Record<string, NodeRuntimeState>
   onNodesChange: (changes: NodeChange[]) => void
   onEdgesChange: (changes: EdgeChange[]) => void
   setEdges: (updater: (edges: Edge[]) => Edge[]) => void
   addNode: (type: NodeType) => void
+  setNodeExecutionState: (nodeId: string, state: NodeExecutionState) => void
+  setNodeParamValue: (nodeId: string, paramId: string, value: unknown) => void
+  setNodeImagePreview: (nodeId: string, outputId: string, dataUrl: string | null) => void
+  getOrCreateNodeRuntime: (nodeId: string) => NodeRuntimeState
+}
+
+function createDefaultRuntime(): NodeRuntimeState {
+  return { executionState: 'idle', paramValues: {}, imagePreviews: {} }
 }
 
 export const useFlowStore = create<FlowState>((set, get) => ({
   nodes: createInitialNodes(),
   edges: createInitialEdges(),
+  nodeRuntimeStates: {},
 
   onNodesChange: (changes: NodeChange[]) => {
     set({ nodes: applyNodeChanges(changes, get().nodes) })
@@ -40,5 +60,45 @@ export const useFlowStore = create<FlowState>((set, get) => ({
     const nodeCount = get().nodes.length
     const newNode = buildNewNode(type, nodeCount)
     set({ nodes: [...get().nodes, newNode] })
+  },
+
+  getOrCreateNodeRuntime: (nodeId: string): NodeRuntimeState => {
+    return get().nodeRuntimeStates[nodeId] ?? createDefaultRuntime()
+  },
+
+  setNodeExecutionState: (nodeId: string, state: NodeExecutionState) => {
+    const existing = get().nodeRuntimeStates[nodeId] ?? createDefaultRuntime()
+    set({
+      nodeRuntimeStates: {
+        ...get().nodeRuntimeStates,
+        [nodeId]: { ...existing, executionState: state }
+      }
+    })
+  },
+
+  setNodeParamValue: (nodeId: string, paramId: string, value: unknown) => {
+    const existing = get().nodeRuntimeStates[nodeId] ?? createDefaultRuntime()
+    set({
+      nodeRuntimeStates: {
+        ...get().nodeRuntimeStates,
+        [nodeId]: {
+          ...existing,
+          paramValues: { ...existing.paramValues, [paramId]: value }
+        }
+      }
+    })
+  },
+
+  setNodeImagePreview: (nodeId: string, outputId: string, dataUrl: string | null) => {
+    const existing = get().nodeRuntimeStates[nodeId] ?? createDefaultRuntime()
+    set({
+      nodeRuntimeStates: {
+        ...get().nodeRuntimeStates,
+        [nodeId]: {
+          ...existing,
+          imagePreviews: { ...existing.imagePreviews, [outputId]: dataUrl }
+        }
+      }
+    })
   }
 }))

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -14,6 +14,29 @@ export interface NodeData {
 
 export type NodeType = 'imageSource' | 'filter' | 'output' | 'custom'
 
+// ─── Port Type System ─────────────────────────────────────────────────────────
+
+/** Describes a named, color-coded port type. */
+export interface PortType {
+  id: string
+  label: string
+  color: string
+}
+
+/** Registry of all built-in port types. */
+export const PORT_TYPE_REGISTRY: Record<string, PortType> = {
+  IMAGE: { id: 'IMAGE', label: 'Image', color: '#64B5F6' },
+  TEXT: { id: 'TEXT', label: 'Text', color: '#81C784' },
+  NUMBER: { id: 'NUMBER', label: 'Number', color: '#FFB74D' },
+  JSON: { id: 'JSON', label: 'JSON', color: '#CE93D8' },
+  ANY: { id: 'ANY', label: 'Any', color: '#9E9E9E' }
+}
+
+/** Resolves a port type id to its PortType, falling back to ANY. */
+export function resolvePortType(typeId: string): PortType {
+  return PORT_TYPE_REGISTRY[typeId] ?? PORT_TYPE_REGISTRY.ANY
+}
+
 // ─── Plugin / Node Definition types ──────────────────────────────────────────
 
 /** Describes a single input or output port on a node. */
@@ -22,6 +45,38 @@ export interface PortDefinition {
   label: string
   type: string
 }
+
+/** Describes a parameter (inline widget) on a node. */
+export type ParameterType =
+  | 'text'
+  | 'number'
+  | 'slider'
+  | 'toggle'
+  | 'select'
+  | 'textarea'
+
+export interface SelectOption {
+  value: string
+  label: string
+}
+
+export interface ParameterDefinition {
+  id: string
+  label: string
+  type: ParameterType
+  default?: unknown
+  /** For slider and number: min value */
+  min?: number
+  /** For slider and number: max value */
+  max?: number
+  /** For slider: step size */
+  step?: number
+  /** For select: available options */
+  options?: SelectOption[]
+}
+
+/** Execution state for a node instance. */
+export type NodeExecutionState = 'idle' | 'running' | 'completed' | 'error'
 
 /**
  * Defines a node type that a plugin exports.
@@ -34,5 +89,8 @@ export interface NodeDefinition {
   description?: string
   inputs: PortDefinition[]
   outputs: PortDefinition[]
+  parameters?: ParameterDefinition[]
+  /** Optional pixel width override. Defaults to 280. */
+  width?: number
   execute: (inputs: Record<string, unknown>) => Promise<Record<string, unknown>> | Record<string, unknown>
 }


### PR DESCRIPTION
## Summary

Implements the `GenericNode` React Flow component that renders any `NodeDefinition` as a visual node on the canvas. This enables plugin-authored node types to appear on the canvas without requiring hard-coded React components.

## Changes

- `src/shared/types.ts` — Added `ParameterDefinition`, `ParameterType`, `PortType`, `PORT_TYPE_REGISTRY`, `resolvePortType()`, `NodeExecutionState`, and `width` field to `NodeDefinition`
- `src/renderer/src/store/flow-store.ts` — Extended Zustand store with per-node runtime state (execution state, parameter values, image previews)
- `src/renderer/src/components/nodes/GenericNode.tsx` — Main memoized generic node component (uses `NodeDefinition` from `data.definition`)
- `src/renderer/src/components/nodes/NodeHeader.tsx` — Node header with name, category badge, state indicator, and run button
- `src/renderer/src/components/nodes/NodeHandles.tsx` — Color-coded input/output handles with tooltips showing port name and type
- `src/renderer/src/components/nodes/NodeImagePreview.tsx` — Thumbnail preview section for IMAGE-type outputs
- `src/renderer/src/components/nodes/nodeTypeRegistry.ts` — `buildNodeTypes()` function merging base types with plugin definitions
- `src/renderer/src/components/widgets/` — Six widget components: TextWidget, NumberWidget, SliderWidget, ToggleWidget, SelectWidget, TextAreaWidget; dispatched by `ParameterWidget`
- `src/renderer/src/components/Canvas.tsx` — Updated to use `buildNodeTypes()` instead of hardcoded `nodeTypes` map
- `src/__tests__/generic-node-data.test.ts` — 17 tests covering PORT_TYPE_REGISTRY, resolvePortType, buildNodeTypes, and flow store runtime state

## Test Plan

- All 67 tests pass (50 pre-existing + 17 new)
- Happy path: `buildNodeTypes([def])` includes the def id as a key and preserves base types
- Edge case 1: `resolvePortType('UNKNOWN')` falls back to ANY
- Edge case 2: `buildNodeTypes([])` returns all three base types
- Edge case 3: multiple node runtime states are independent per node id
- Edge case 4: `setNodeImagePreview` with `null` clears a previously set preview

Fixes #26