### PR TITLE
Update Tailwind theme to darker flat palette

### DIFF
--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -85,27 +85,27 @@
 
 /* React Flow overrides for dark theme */
 .react-flow__background {
-  background-color: #1a1a2e;
+  background-color: #0d0d0d;
 }
 
 .react-flow__controls {
-  background: #1e1e2e;
-  border: 1px solid #45475a;
+  background: #1a1a1a;
+  border: 1px solid #2a2a2a;
   border-radius: 8px;
 }
 
 .react-flow__controls-button {
-  background: #1e1e2e;
-  border-bottom: 1px solid #45475a;
-  color: #cdd6f4;
+  background: #1a1a1a;
+  border-bottom: 1px solid #2a2a2a;
+  color: #cccccc;
 }
 
 .react-flow__controls-button:hover {
-  background: #313244;
+  background: #222222;
 }
 
 .react-flow__minimap {
-  background-color: #1e1e2e;
-  border: 1px solid #45475a;
+  background-color: #1a1a1a;
+  border: 1px solid #2a2a2a;
   border-radius: 8px;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,16 +8,16 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        // Custom dark theme palette
+        // Custom dark theme palette — darker flat aesthetic
         canvas: {
-          bg: '#1a1a2e',
-          surface: '#16213e',
-          border: '#0f3460'
+          bg: '#0d0d0d',
+          surface: '#141414',
+          border: '#2a2a2a'
         },
         node: {
-          bg: '#1e1e2e',
-          header: '#313244',
-          border: '#45475a',
+          bg: '#1a1a1a',
+          header: '#222222',
+          border: '#333333',
           selected: '#89b4fa'
         }
       }


### PR DESCRIPTION
## Summary
- Replaces the blue-tinted dark palette (`#1a1a2e`, `#16213e`, etc.) with a near-black flat aesthetic matching the weavy.ai reference design
- All seven color tokens updated in `tailwind.config.js` while keeping the same key names (`canvas-bg`, `canvas-surface`, `canvas-border`, `node-bg`, `node-header`, `node-border`, `node-selected`) so no component code changes are needed
- React Flow overrides in `globals.css` updated to use the new palette values directly

## Changes
- `tailwind.config.js` — new flat palette: canvas-bg #0d0d0d, canvas-surface #141414, canvas-border #2a2a2a, node-bg #1a1a1a, node-header #222222, node-border #333333, node-selected #89b4fa (unchanged)
- `src/renderer/src/styles/globals.css` — React Flow overrides (background, controls, minimap) updated to match new palette; button text color updated to #cccccc for readability on near-black surfaces

## Test Plan
- [ ] App launches; canvas background is near-black (#0d0d0d)
- [ ] Nodes render with dark gray body (#1a1a1a) and slightly lighter header (#222222)
- [ ] Borders are subtle but visible (#333333 for nodes, #2a2a2a for canvas elements)
- [ ] Selected node accent border remains blue (#89b4fa)
- [ ] Text (white) is readable against all dark surfaces
- [ ] Port type colors (IMAGE blue, TEXT green, etc.) remain distinguishable
- [ ] React Flow controls and minimap display with updated dark styling

Fixes #49