### PR TITLE
Update canvas chrome: subtler grid, hide minimap, restyle controls

### DIFF
--- a/.claude/agent-learnings/entries/2026-03-14T09-10-00-dev.json
+++ b/.claude/agent-learnings/entries/2026-03-14T09-10-00-dev.json
@@ -1,0 +1,9 @@
+{
+  "timestamp": "2026-03-14T09:10:00Z",
+  "agent": "dev",
+  "issue": "#54",
+  "category": "pattern",
+  "summary": "Canvas chrome subtlety: grid 0.5px dots at #1f1f1f, controls scale(0.85), minimap toggled via IPC+zustand",
+  "detail": "Issue #54 updated canvas visual chrome to match weavy.ai reference. Key changes: (1) Background dot size reduced from 1 to 0.5, color changed from #313244 to #1f1f1f (near-invisible on #0d0d0d bg), (2) MiniMap removed from default render; controlled by showMiniMap boolean in ui-store (default false), (3) Controls wrapped in style={{ transform: 'scale(0.85)', transformOrigin: 'bottom left' }} to appear smaller, (4) View menu in main/index.ts gets 'Toggle MiniMap' item (CmdOrCtrl+M) that sends IPC_CHANNELS.APP_TOGGLE_MINIMAP, (5) Layout.tsx listens for app:toggle-minimap IPC event and calls toggleMiniMap from ui-store, (6) globals.css controls updated to #141414 bg and smaller SVG icon sizing. Pattern: for IPC-driven UI toggles, add channel to shared/ipc-channels.ts, send from main/index.ts menu, receive in Layout.tsx useEffect, store state in ui-store.ts.",
+  "tags": ["canvas", "react-flow", "minimap", "ui-store", "ipc", "css", "electron-menu"]
+}

--- a/src/__tests__/ui-store.test.ts
+++ b/src/__tests__/ui-store.test.ts
@@ -4,7 +4,7 @@ import { useUiStore } from '../renderer/src/store/ui-store'
 describe('useUiStore', () => {
   // Reset store state between tests
   beforeEach(() => {
-    useUiStore.setState({ leftPanelOpen: true, rightPanelOpen: true })
+    useUiStore.setState({ leftPanelOpen: true, rightPanelOpen: true, showMiniMap: false })
   })
 
   // Happy path: default state has both panels open
@@ -62,5 +62,44 @@ describe('useUiStore', () => {
     expect(useUiStore.getState().rightPanelOpen).toBe(false)
     setRightPanel(true)
     expect(useUiStore.getState().rightPanelOpen).toBe(true)
+  })
+})
+
+describe('useUiStore — minimap', () => {
+  // Reset store state between tests
+  beforeEach(() => {
+    useUiStore.setState({ showMiniMap: false })
+  })
+
+  // Happy path: minimap is hidden by default
+  it('initializes with showMiniMap false', () => {
+    const state = useUiStore.getState()
+    expect(state.showMiniMap).toBe(false)
+  })
+
+  // Edge case 1: toggleMiniMap shows the minimap
+  it('toggleMiniMap turns showMiniMap on when it was off', () => {
+    const { toggleMiniMap } = useUiStore.getState()
+    toggleMiniMap()
+    expect(useUiStore.getState().showMiniMap).toBe(true)
+  })
+
+  // Edge case 2: double-toggle returns minimap to hidden
+  it('double toggleMiniMap returns showMiniMap to false', () => {
+    const { toggleMiniMap } = useUiStore.getState()
+    toggleMiniMap()
+    useUiStore.getState().toggleMiniMap()
+    expect(useUiStore.getState().showMiniMap).toBe(false)
+  })
+
+  // Edge case 3: toggleMiniMap is independent of panel state
+  it('toggling minimap does not affect panel open states', () => {
+    useUiStore.setState({ leftPanelOpen: true, rightPanelOpen: true })
+    const { toggleMiniMap } = useUiStore.getState()
+    toggleMiniMap()
+    const state = useUiStore.getState()
+    expect(state.showMiniMap).toBe(true)
+    expect(state.leftPanelOpen).toBe(true)
+    expect(state.rightPanelOpen).toBe(true)
   })
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -110,7 +110,13 @@ function buildAppMenu(mainWindow: BrowserWindow): Menu {
         { role: 'forceReload' },
         { role: 'toggleDevTools' },
         { type: 'separator' },
-        { role: 'togglefullscreen' }
+        { role: 'togglefullscreen' },
+        { type: 'separator' },
+        {
+          label: 'Toggle MiniMap',
+          accelerator: 'CmdOrCtrl+M',
+          click: () => mainWindow.webContents.send(IPC_CHANNELS.APP_TOGGLE_MINIMAP)
+        }
       ]
     }
   ]

--- a/src/renderer/src/components/Canvas.tsx
+++ b/src/renderer/src/components/Canvas.tsx
@@ -13,6 +13,7 @@ import {
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { useFlowStore } from '../store/flow-store'
+import { useUiStore } from '../store/ui-store'
 import { buildNodeTypes } from './nodes/nodeTypeRegistry'
 import TypedEdge from './TypedEdge'
 import { validateConnection, buildTypedEdgeData } from '../utils/connection-utils'
@@ -67,6 +68,7 @@ export function triggerRejectionAnimation(el: HTMLElement, durationMs: number): 
 
 export default function Canvas(): React.JSX.Element {
   const { nodes, edges, onNodesChange, onEdgesChange, setEdges } = useFlowStore()
+  const { showMiniMap } = useUiStore()
   const isDraggingRef = useRef(false)
   const connectionAcceptedRef = useRef(false)
   const canvasWrapperRef = useRef<HTMLDivElement>(null)
@@ -151,13 +153,18 @@ export default function Canvas(): React.JSX.Element {
         maxZoom={4}
         deleteKeyCode="Delete"
       >
-        <Background variant={BackgroundVariant.Dots} gap={16} size={1} color="#313244" />
-        <Controls showInteractive={false} />
-        <MiniMap
-          nodeColor="#313244"
-          maskColor="rgba(26, 26, 46, 0.8)"
-          style={{ background: '#1e1e2e' }}
+        <Background variant={BackgroundVariant.Dots} gap={16} size={0.5} color="#1f1f1f" />
+        <Controls
+          showInteractive={false}
+          style={{ transform: 'scale(0.85)', transformOrigin: 'bottom left' }}
         />
+        {showMiniMap && (
+          <MiniMap
+            nodeColor="#313244"
+            maskColor="rgba(13, 13, 13, 0.8)"
+            style={{ background: '#141414' }}
+          />
+        )}
         <WorkflowController />
       </ReactFlow>
 

--- a/src/renderer/src/components/Layout.tsx
+++ b/src/renderer/src/components/Layout.tsx
@@ -91,13 +91,26 @@ function GalleryToggleButton(): React.JSX.Element {
 }
 
 export default function Layout(): React.JSX.Element {
-  const { leftPanelOpen, rightPanelOpen, settingsOpen, openSettings, closeSettings } = useUiStore()
+  const {
+    leftPanelOpen,
+    rightPanelOpen,
+    settingsOpen,
+    openSettings,
+    closeSettings,
+    toggleMiniMap
+  } = useUiStore()
 
   // Listen for the main-process "open settings" IPC event (File → Settings menu)
   useEffect(() => {
     window.electron.ipcRenderer.on('app:open-settings', openSettings)
     return () => window.electron.ipcRenderer.off('app:open-settings', openSettings)
   }, [openSettings])
+
+  // Listen for the main-process "toggle minimap" IPC event (View → Toggle MiniMap menu)
+  useEffect(() => {
+    window.electron.ipcRenderer.on('app:toggle-minimap', toggleMiniMap)
+    return () => window.electron.ipcRenderer.off('app:toggle-minimap', toggleMiniMap)
+  }, [toggleMiniMap])
 
   return (
     <div className="flex flex-col h-screen w-screen bg-canvas-bg text-white overflow-hidden">

--- a/src/renderer/src/store/ui-store.ts
+++ b/src/renderer/src/store/ui-store.ts
@@ -4,18 +4,21 @@ interface UiState {
   leftPanelOpen: boolean
   rightPanelOpen: boolean
   settingsOpen: boolean
+  showMiniMap: boolean
   toggleLeftPanel: () => void
   toggleRightPanel: () => void
   setLeftPanel: (open: boolean) => void
   setRightPanel: (open: boolean) => void
   openSettings: () => void
   closeSettings: () => void
+  toggleMiniMap: () => void
 }
 
 export const useUiStore = create<UiState>(set => ({
   leftPanelOpen: true,
   rightPanelOpen: true,
   settingsOpen: false,
+  showMiniMap: false,
 
   toggleLeftPanel: () => set(state => ({ leftPanelOpen: !state.leftPanelOpen })),
   toggleRightPanel: () => set(state => ({ rightPanelOpen: !state.rightPanelOpen })),
@@ -24,5 +27,7 @@ export const useUiStore = create<UiState>(set => ({
   setRightPanel: (open: boolean) => set({ rightPanelOpen: open }),
 
   openSettings: () => set({ settingsOpen: true }),
-  closeSettings: () => set({ settingsOpen: false })
+  closeSettings: () => set({ settingsOpen: false }),
+
+  toggleMiniMap: () => set(state => ({ showMiniMap: !state.showMiniMap }))
 }))

--- a/src/renderer/src/styles/globals.css
+++ b/src/renderer/src/styles/globals.css
@@ -116,23 +116,32 @@
 }
 
 .react-flow__controls {
-  background: #1a1a1a;
+  background: #141414;
   border: 1px solid #2a2a2a;
-  border-radius: 8px;
+  border-radius: 6px;
+  box-shadow: none;
 }
 
 .react-flow__controls-button {
-  background: #1a1a1a;
+  background: #141414;
   border-bottom: 1px solid #2a2a2a;
-  color: #cccccc;
+  color: #666666;
+  width: 20px;
+  height: 20px;
 }
 
 .react-flow__controls-button:hover {
-  background: #222222;
+  background: #1e1e1e;
+  color: #aaaaaa;
+}
+
+.react-flow__controls-button svg {
+  max-width: 10px;
+  max-height: 10px;
 }
 
 .react-flow__minimap {
-  background-color: #1a1a1a;
+  background-color: #141414;
   border: 1px solid #2a2a2a;
-  border-radius: 8px;
+  border-radius: 6px;
 }

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -36,6 +36,9 @@ export const IPC_CHANNELS = {
   WORKFLOW_MENU_NEW: 'workflow:menu-new',
   WORKFLOW_MENU_OPEN_RECENT: 'workflow:menu-open-recent',
 
+  // UI toggle channels
+  APP_TOGGLE_MINIMAP: 'app:toggle-minimap',
+
   // Gallery / auto-save channels
   GALLERY_LIST: 'gallery:list',
   GALLERY_SAVE_IMAGE: 'gallery:save-image',


### PR DESCRIPTION
## Summary

Updates the Canvas component and surrounding UI to match the weavy.ai reference aesthetic — near-invisible grid dots, hidden minimap by default (toggle via View menu), and smaller more subtle zoom controls.

## Changes

- `src/renderer/src/components/Canvas.tsx` — Background dot size 1→0.5, dot color `#313244`→`#1f1f1f`; MiniMap conditionally rendered based on `showMiniMap` from ui-store; Controls scaled to 0.85 via inline style
- `src/renderer/src/store/ui-store.ts` — Added `showMiniMap: boolean` (default `false`) and `toggleMiniMap()` action
- `src/shared/ipc-channels.ts` — Added `APP_TOGGLE_MINIMAP: 'app:toggle-minimap'` constant
- `src/main/index.ts` — Added "Toggle MiniMap" item (CmdOrCtrl+M) to View menu; sends IPC event on click
- `src/renderer/src/components/Layout.tsx` — `useEffect` listens for `app:toggle-minimap` IPC and calls `toggleMiniMap`
- `src/renderer/src/styles/globals.css` — Controls CSS updated to `#141414` background, `#2a2a2a` border, smaller SVG icon sizing; minimap CSS updated to match
- `src/__tests__/ui-store.test.ts` — Added 4 tests for the new minimap toggle behavior

## Test Plan

- [x] Run `npm test` — 16/16 ui-store + ipc-channels tests pass, 371 others pass (14 pre-existing failures in core-type-system unrelated to this PR)
- [ ] Launch app — canvas shows very subtle near-invisible dots on near-black background
- [ ] Zoom controls appear smaller and less prominent (bottom-left)
- [ ] MiniMap is hidden by default
- [ ] View > Toggle MiniMap (or CmdOrCtrl+M) reveals/hides minimap

Fixes #54