### PR TITLE
Enlarge image preview and redesign node card layout (#53)

### DIFF
--- a/src/__tests__/node-card-layout.test.ts
+++ b/src/__tests__/node-card-layout.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the node card layout feature (issue #53):
+ * - IMAGE-output nodes default to 450px width
+ * - Utility nodes (no IMAGE outputs) default to 280px width
+ * - hasImageOutput helper works correctly
+ * - resolveNodeWidth respects explicit width and IMAGE detection
+ * - buildNewNode / buildNewNodeAtPosition propagate width in style
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  hasImageOutput,
+  resolveNodeWidth,
+  buildNewNode,
+  buildNewNodeAtPosition,
+  IMAGE_NODE_WIDTH,
+  UTILITY_NODE_WIDTH
+} from '../renderer/src/store/flow-node-factory'
+import type { NodeDefinition } from '../shared/types'
+
+const mockExecute = async (): Promise<Record<string, unknown>> => ({})
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeDefinition(overrides: Partial<NodeDefinition> = {}): NodeDefinition {
+  return {
+    id: 'test/node',
+    name: 'Test Node',
+    category: 'test',
+    inputs: [],
+    outputs: [],
+    execute: mockExecute,
+    ...overrides
+  }
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+describe('width constants', () => {
+  it('IMAGE_NODE_WIDTH is 450', () => {
+    expect(IMAGE_NODE_WIDTH).toBe(450)
+  })
+
+  it('UTILITY_NODE_WIDTH is 280', () => {
+    expect(UTILITY_NODE_WIDTH).toBe(280)
+  })
+})
+
+// ─── hasImageOutput ───────────────────────────────────────────────────────────
+
+describe('hasImageOutput', () => {
+  // Happy path: node with one IMAGE output
+  it('returns true when the definition has an IMAGE output', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'img', label: 'Image', type: 'IMAGE' }]
+    })
+    expect(hasImageOutput(def)).toBe(true)
+  })
+
+  // Edge case 1: utility node with TEXT output only
+  it('returns false when outputs are non-IMAGE', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'txt', label: 'Text', type: 'TEXT' }]
+    })
+    expect(hasImageOutput(def)).toBe(false)
+  })
+
+  // Edge case 2: no outputs at all
+  it('returns false when outputs array is empty', () => {
+    const def = makeDefinition({ outputs: [] })
+    expect(hasImageOutput(def)).toBe(false)
+  })
+
+  // Edge case 3: mixed outputs — still counts as image node if any are IMAGE
+  it('returns true when at least one output is IMAGE among mixed types', () => {
+    const def = makeDefinition({
+      outputs: [
+        { id: 'txt', label: 'Text', type: 'TEXT' },
+        { id: 'img', label: 'Image', type: 'IMAGE' }
+      ]
+    })
+    expect(hasImageOutput(def)).toBe(true)
+  })
+})
+
+// ─── resolveNodeWidth ─────────────────────────────────────────────────────────
+
+describe('resolveNodeWidth', () => {
+  // Happy path: IMAGE definition returns 450
+  it('returns IMAGE_NODE_WIDTH for a definition with IMAGE output', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'img', label: 'Image', type: 'IMAGE' }]
+    })
+    expect(resolveNodeWidth(def)).toBe(IMAGE_NODE_WIDTH)
+  })
+
+  // Edge case 1: utility definition returns 280
+  it('returns UTILITY_NODE_WIDTH for a definition with no IMAGE outputs', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'txt', label: 'Text', type: 'TEXT' }]
+    })
+    expect(resolveNodeWidth(def)).toBe(UTILITY_NODE_WIDTH)
+  })
+
+  // Edge case 2: explicit width overrides auto-detection
+  it('respects explicit definition.width over IMAGE detection', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'img', label: 'Image', type: 'IMAGE' }],
+      width: 600
+    })
+    expect(resolveNodeWidth(def)).toBe(600)
+  })
+
+  // Edge case 3: no definition returns undefined
+  it('returns undefined when no definition is provided', () => {
+    expect(resolveNodeWidth(undefined)).toBeUndefined()
+  })
+})
+
+// ─── buildNewNode width propagation ──────────────────────────────────────────
+
+describe('buildNewNode — width propagation', () => {
+  // Happy path: IMAGE node gets style.width = 450
+  it('sets style.width to 450 for a definition with IMAGE output', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'img', label: 'Image', type: 'IMAGE' }]
+    })
+    const node = buildNewNode('generic', 0, def)
+    expect((node.style as React.CSSProperties | undefined)?.width).toBe(450)
+  })
+
+  // Edge case 1: utility node gets style.width = 280
+  it('sets style.width to 280 for a utility definition', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'txt', label: 'Text', type: 'TEXT' }]
+    })
+    const node = buildNewNode('utility.text', 0, def)
+    expect((node.style as React.CSSProperties | undefined)?.width).toBe(280)
+  })
+
+  // Edge case 2: explicit width honored
+  it('sets style.width to explicit definition.width when provided', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'img', label: 'Image', type: 'IMAGE' }],
+      width: 350
+    })
+    const node = buildNewNode('generic', 0, def)
+    expect((node.style as React.CSSProperties | undefined)?.width).toBe(350)
+  })
+
+  // Edge case 3: no definition means no style.width
+  it('does not set style when no definition is provided', () => {
+    const node = buildNewNode('imageSource', 0)
+    expect(node.style).toBeUndefined()
+  })
+})
+
+// ─── buildNewNodeAtPosition width propagation ─────────────────────────────────
+
+describe('buildNewNodeAtPosition — width propagation', () => {
+  // Happy path: IMAGE node at given position gets correct width
+  it('sets style.width to 450 for IMAGE definition at given position', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'img', label: 'Image', type: 'IMAGE' }]
+    })
+    const node = buildNewNodeAtPosition('generic', 100, 200, def)
+    expect(node.position.x).toBe(100)
+    expect(node.position.y).toBe(200)
+    expect((node.style as React.CSSProperties | undefined)?.width).toBe(450)
+  })
+
+  // Edge case 1: utility node at position gets width 280
+  it('sets style.width to 280 for utility definition at given position', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'txt', label: 'Text', type: 'TEXT' }]
+    })
+    const node = buildNewNodeAtPosition('utility.text', 50, 75, def)
+    expect((node.style as React.CSSProperties | undefined)?.width).toBe(280)
+  })
+
+  // Edge case 2: no definition at position — no style
+  it('does not set style when no definition is provided', () => {
+    const node = buildNewNodeAtPosition('filter', 0, 0)
+    expect(node.style).toBeUndefined()
+  })
+
+  // Edge case 3: explicit width wins over IMAGE auto-detection
+  it('respects explicit definition.width at position', () => {
+    const def = makeDefinition({
+      outputs: [{ id: 'img', label: 'Image', type: 'IMAGE' }],
+      width: 500
+    })
+    const node = buildNewNodeAtPosition('generic', 0, 0, def)
+    expect((node.style as React.CSSProperties | undefined)?.width).toBe(500)
+  })
+})

--- a/src/renderer/src/components/nodes/GenericNode.tsx
+++ b/src/renderer/src/components/nodes/GenericNode.tsx
@@ -1,7 +1,8 @@
 import React, { memo, useCallback } from 'react'
 import { NodeProps, Position } from '@xyflow/react'
-import type { NodeDefinition, NodeExecutionState, ParameterDefinition } from '../../../../shared/types'
+import type { NodeDefinition, NodeExecutionState, ParameterDefinition, PortDefinition } from '../../../../shared/types'
 import { useFlowStore } from '../../store/flow-store'
+import { hasImageOutput, IMAGE_NODE_WIDTH, UTILITY_NODE_WIDTH } from '../../store/flow-node-factory'
 import NodeHeader from './NodeHeader'
 import NodeHandles from './NodeHandles'
 import NodeImagePreview from './NodeImagePreview'
@@ -12,8 +13,6 @@ export interface GenericNodeData {
   definition: NodeDefinition
   [key: string]: unknown
 }
-
-const DEFAULT_WIDTH = 280
 
 // ─── RunButton ────────────────────────────────────────────────────────────────
 
@@ -113,6 +112,42 @@ function PortLabels({
   )
 }
 
+// ─── PortCountFooter ──────────────────────────────────────────────────────────
+
+/**
+ * Counts ports by type and renders small gray badges at the bottom of the node.
+ * Example: "1 image  2 text"
+ */
+function PortCountFooter({
+  inputs,
+  outputs
+}: {
+  inputs: PortDefinition[]
+  outputs: PortDefinition[]
+}): React.JSX.Element {
+  const allPorts = [...inputs, ...outputs]
+  if (allPorts.length === 0) return <></>
+
+  // Count occurrences of each port type across inputs + outputs
+  const counts = new Map<string, number>()
+  for (const port of allPorts) {
+    const key = port.type.toLowerCase()
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  const badges = Array.from(counts.entries()).map(([type, count]) => (
+    <span key={type} className="text-[9px] text-gray-600">
+      {count} {type}
+    </span>
+  ))
+
+  return (
+    <div className="flex gap-2 px-3 py-1 border-t border-node-border">
+      {badges}
+    </div>
+  )
+}
+
 // ─── GenericNodeInner ─────────────────────────────────────────────────────────
 
 function GenericNodeInner({ id, data, selected }: NodeProps): React.JSX.Element {
@@ -142,8 +177,14 @@ function GenericNodeInner({ id, data, selected }: NodeProps): React.JSX.Element 
   const instanceNumber = instanceIndex >= 0 ? instanceIndex + 1 : 1
   const instanceLabel = `${definition.name} ${instanceNumber}`
 
-  const nodeWidth = definition.width ?? DEFAULT_WIDTH
-  const borderClass = selected ? 'border-node-selected' : 'border-node-border'
+  // Width: explicit definition.width > IMAGE-aware default > utility default
+  const nodeWidth =
+    definition.width ?? (hasImageOutput(definition) ? IMAGE_NODE_WIDTH : UTILITY_NODE_WIDTH)
+
+  // Border: selected nodes glow blue, others use the subtle dark border
+  const borderStyle = selected
+    ? { border: '1px solid #89b4fa', boxShadow: '0 0 0 2px rgba(137,180,250,0.25)' }
+    : { border: '1px solid #2a2a2a' }
 
   return (
     // Outer wrapper: relative so the instance label can be absolutely positioned above
@@ -156,9 +197,10 @@ function GenericNodeInner({ id, data, selected }: NodeProps): React.JSX.Element 
         {instanceLabel}
       </div>
 
-      {/* Node card */}
+      {/* Node card: rounded-xl for ~12px border-radius, very subtle border */}
       <div
-        className={`node-card ${borderClass} flex flex-col overflow-hidden`}
+        className="bg-node-bg rounded-xl flex flex-col overflow-hidden shadow-lg"
+        style={borderStyle}
         data-testid={`generic-node-${definition.id}`}
       >
         <NodeHeader
@@ -182,6 +224,12 @@ function GenericNodeInner({ id, data, selected }: NodeProps): React.JSX.Element 
         <NodeImagePreview
           outputs={definition.outputs}
           imagePreviews={runtime.imagePreviews}
+        />
+
+        {/* Port count footer badges */}
+        <PortCountFooter
+          inputs={definition.inputs}
+          outputs={definition.outputs}
         />
 
         {/* Bottom bar: run button aligned to the right */}

--- a/src/renderer/src/components/nodes/NodeImagePreview.tsx
+++ b/src/renderer/src/components/nodes/NodeImagePreview.tsx
@@ -20,12 +20,13 @@ function ImagePreviewItem({
         <img
           src={dataUrl}
           alt={port.label}
-          className="w-full rounded border border-node-border object-contain max-h-32"
+          className="w-full rounded-lg border border-node-border object-contain"
         />
       ) : (
         <div
-          className="w-full h-20 rounded border border-node-border bg-canvas-bg
+          className="w-full rounded-lg border border-node-border bg-canvas-bg
                      flex items-center justify-center text-gray-600 text-[10px]"
+          style={{ minHeight: '240px' }}
           aria-label={`${port.label} preview placeholder`}
         >
           No image

--- a/src/renderer/src/store/flow-node-factory.ts
+++ b/src/renderer/src/store/flow-node-factory.ts
@@ -8,6 +8,12 @@ const NODE_LABELS: Record<string, string> = {
   custom: 'Custom'
 }
 
+/** Default width for utility nodes (no IMAGE outputs). */
+export const UTILITY_NODE_WIDTH = 280
+
+/** Default width for image nodes (has at least one IMAGE output). */
+export const IMAGE_NODE_WIDTH = 450
+
 /** Resolve a display label for a node type, using definition name if available. */
 function resolveLabel(type: NodeType, definition?: NodeDefinition): string {
   if (definition?.name) return definition.name
@@ -15,9 +21,30 @@ function resolveLabel(type: NodeType, definition?: NodeDefinition): string {
 }
 
 /**
+ * Returns true if the definition has at least one IMAGE-type output port.
+ * Used to auto-select the wider 450px node width for image-generation nodes.
+ */
+export function hasImageOutput(definition: NodeDefinition): boolean {
+  return definition.outputs.some(port => port.type === 'IMAGE')
+}
+
+/**
+ * Resolves the pixel width for a node from its definition.
+ * - Explicit `definition.width` takes highest precedence.
+ * - Definitions with IMAGE outputs default to IMAGE_NODE_WIDTH (450).
+ * - All other nodes default to UTILITY_NODE_WIDTH (280).
+ */
+export function resolveNodeWidth(definition?: NodeDefinition): number | undefined {
+  if (!definition) return undefined
+  if (definition.width !== undefined) return definition.width
+  return hasImageOutput(definition) ? IMAGE_NODE_WIDTH : UTILITY_NODE_WIDTH
+}
+
+/**
  * Builds a new React Flow node at a staggered position.
  * If a NodeDefinition is provided (for plugin nodes), it is stored in
  * node.data.definition so GenericNode can access port/parameter metadata.
+ * The node style.width is set based on whether the definition has IMAGE outputs.
  */
 export function buildNewNode(
   type: NodeType,
@@ -25,6 +52,7 @@ export function buildNewNode(
   definition?: NodeDefinition
 ): Node {
   const offset = existingCount * 20
+  const width = resolveNodeWidth(definition)
   return {
     id: `${type}-${Date.now()}`,
     type,
@@ -35,7 +63,8 @@ export function buildNewNode(
     data: {
       label: resolveLabel(type, definition),
       ...(definition ? { definition } : {})
-    }
+    },
+    ...(width !== undefined ? { style: { width } } : {})
   }
 }
 
@@ -43,6 +72,7 @@ export function buildNewNode(
  * Builds a new React Flow node at the given canvas position.
  * If a NodeDefinition is provided (for plugin nodes), it is stored in
  * node.data.definition so GenericNode can access port/parameter metadata.
+ * The node style.width is set based on whether the definition has IMAGE outputs.
  */
 export function buildNewNodeAtPosition(
   type: NodeType,
@@ -50,6 +80,7 @@ export function buildNewNodeAtPosition(
   y: number,
   definition?: NodeDefinition
 ): Node {
+  const width = resolveNodeWidth(definition)
   return {
     id: `${type}-${Date.now()}`,
     type,
@@ -57,6 +88,7 @@ export function buildNewNodeAtPosition(
     data: {
       label: resolveLabel(type, definition),
       ...(definition ? { definition } : {})
-    }
+    },
+    ...(width !== undefined ? { style: { width } } : {})
   }
 }


### PR DESCRIPTION
## Summary
- Image-generation nodes (any output with type `IMAGE`) now render at 450px width; utility nodes stay at 280px
- Node cards use `rounded-xl` (~12px radius) and a subtle `1px #2a2a2a` border
- Selected nodes display a blue border + soft glow (`#89b4fa` with 25% alpha shadow)
- New `PortCountFooter` shows port type counts at the bottom (e.g. "1 image", "1 text")
- `NodeImagePreview` removes `max-height` restriction; placeholder area is min 240px tall; images render at full width with rounded corners

## Changes
- `src/renderer/src/store/flow-node-factory.ts` — add `hasImageOutput`, `resolveNodeWidth`, `IMAGE_NODE_WIDTH`, `UTILITY_NODE_WIDTH` exports; wire `style.width` in both build functions
- `src/renderer/src/components/nodes/GenericNode.tsx` — image-aware width, `rounded-xl` + inline `border` style, `selected` blue glow, new `PortCountFooter` component
- `src/renderer/src/components/nodes/NodeImagePreview.tsx` — remove `max-h-32`, raise placeholder to `minHeight: 240px`, add `rounded-lg` to image
- `src/__tests__/node-card-layout.test.ts` — 18 new unit tests covering constants, `hasImageOutput`, `resolveNodeWidth`, and width propagation through both factory functions

## Test Plan
- Happy path: `buildNewNode` with IMAGE output definition sets `style.width = 450`
- Edge case 1: utility definition (TEXT output) sets `style.width = 280`
- Edge case 2: explicit `definition.width` overrides auto-detection
- Edge case 3: no definition provided — no `style` property set
- All 18 new tests pass; 429 pre-existing tests continue to pass

Fixes #53